### PR TITLE
feat: Add auth property to coder_agent_script

### DIFF
--- a/docs/data-sources/agent_script.md
+++ b/docs/data-sources/agent_script.md
@@ -37,6 +37,7 @@ resource "kubernetes_pod" "dev" {
 
 ### Optional
 
+- **auth** (String) The authentication type the agent will use. Must be one of: "token", "google-instance-identity", "aws-instance-identity", "azure-instance-identity".
 - **id** (String) The ID of this resource.
 
 ### Read-Only

--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -30,6 +30,8 @@ resource "kubernetes_pod" "dev" {
 
 ### Read-Only
 
+- **name** (String) Name of the workspace.
 - **transition** (String) Either "start" or "stop". Use this to start/stop resources with "count".
+- **username** (String) Username of the workspace owner.
 
 

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -40,21 +40,13 @@ resource "google_compute_instance" "dev" {
 
 ### Optional
 
-- **auth** (Block List, Max: 1) Authenticate an instance with zero-trust by using cloud metadata APIs. (see [below for nested schema](#nestedblock--auth))
 - **env** (Map of String) A mapping of environment variables to set inside the workspace.
 - **id** (String) The ID of this resource.
+- **instance_id** (String) An instance ID from a provisioned instance to enable zero-trust agent authentication.
 - **startup_script** (String) A script to run after the agent starts.
 
 ### Read-Only
 
 - **token** (String) Set the environment variable "CODER_TOKEN" with this token to authenticate an agent.
-
-<a id="nestedblock--auth"></a>
-### Nested Schema for `auth`
-
-Optional:
-
-- **instance_id** (String) A unique ID from the created compute resource to identify with cloud metadata APIs.
-- **type** (String) The authentication type to use. Must be one of: "google-instance-identity".
 
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -117,10 +117,7 @@ func TestAgent(t *testing.T) {
 					url = "https://example.com"
 				}
 				resource "coder_agent" "new" {
-					auth {
-						type = "google-instance-identity"
-						instance_id = "instance"
-					}
+					instance_id = "instance"
 					env = {
 						hi = "test"
 					}
@@ -133,8 +130,7 @@ func TestAgent(t *testing.T) {
 					require.NotNil(t, resource)
 					for _, key := range []string{
 						"token",
-						"auth.0.type",
-						"auth.0.instance_id",
+						"instance_id",
 						"env.hi",
 						"startup_script",
 					} {


### PR DESCRIPTION
This enables explicit definition of auth type, so the agent
doesn't misinterpret the running environment.

This also adds "username" and "name" properties to "coder_workspace"
to allow for pretty resource naming inside a cloud.