### PR TITLE
feat: Add "dir" option to "coder_agent"

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -19,6 +19,7 @@ data "coder_workspace" "me" {
 resource "coder_agent" "dev" {
   os   = "linux"
   arch = "amd64"
+  dir  = "/workspace"
 }
 
 resource "kubernetes_pod" "dev" {
@@ -46,6 +47,7 @@ resource "kubernetes_pod" "dev" {
 ### Optional
 
 - `auth` (String) The authentication type the agent will use. Must be one of: "token", "google-instance-identity", "aws-instance-identity", "azure-instance-identity".
+- `dir` (String) The starting directory when a user creates a shell session. Defaults to $HOME.
 - `env` (Map of String) A mapping of environment variables to set inside the workspace.
 - `id` (String) The ID of this resource.
 - `startup_script` (String) A script to run after the agent starts.

--- a/examples/resources/coder_agent/resource.tf
+++ b/examples/resources/coder_agent/resource.tf
@@ -4,6 +4,7 @@ data "coder_workspace" "me" {
 resource "coder_agent" "dev" {
   os   = "linux"
   arch = "amd64"
+  dir  = "/workspace"
 }
 
 resource "kubernetes_pod" "dev" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -164,6 +164,12 @@ func New() *schema.Provider {
 						Description:  `The authentication type the agent will use. Must be one of: "token", "google-instance-identity", "aws-instance-identity", "azure-instance-identity".`,
 						ValidateFunc: validation.StringInSlice([]string{"token", "google-instance-identity", "aws-instance-identity", "azure-instance-identity"}, false),
 					},
+					"dir": {
+						Type:        schema.TypeString,
+						ForceNew:    true,
+						Optional:    true,
+						Description: "The starting directory when a user creates a shell session. Defaults to $HOME.",
+					},
 					"env": {
 						ForceNew:    true,
 						Description: "A mapping of environment variables to set inside the workspace.",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -62,6 +62,7 @@ func TestAgent(t *testing.T) {
 					os = "linux"
 					arch = "amd64"
 					auth = "aws-instance-identity"
+					dir = "/tmp"
 					env = {
 						hi = "test"
 					}
@@ -78,6 +79,7 @@ func TestAgent(t *testing.T) {
 					"os",
 					"arch",
 					"auth",
+					"dir",
 					"env.hi",
 					"startup_script",
 				} {


### PR DESCRIPTION
This allows specifying where a shell will be opened
when SSH'ing into a workspace.