### PR TITLE
feat: Rename "CODER_URL" to "CODER_AGENT_URL"

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -26,9 +26,9 @@ func New() *schema.Provider {
 				Type:        schema.TypeString,
 				Description: "The URL to access Coder.",
 				Optional:    true,
-				// The "CODER_URL" environment variable is used by default
+				// The "CODER_AGENT_URL" environment variable is used by default
 				// as the Access URL when generating scripts.
-				DefaultFunc: schema.EnvDefaultFunc("CODER_URL", "https://mydeployment.coder.com"),
+				DefaultFunc: schema.EnvDefaultFunc("CODER_AGENT_URL", "https://mydeployment.coder.com"),
 				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
 					_, err := url.Parse(s)
 					if err != nil {
@@ -44,7 +44,7 @@ func New() *schema.Provider {
 				return nil, diag.Errorf("unexpected type %q for url", reflect.TypeOf(resourceData.Get("url")).String())
 			}
 			if rawURL == "" {
-				return nil, diag.Errorf("CODER_URL must not be empty; got %q", rawURL)
+				return nil, diag.Errorf("CODER_AGENT_URL must not be empty; got %q", rawURL)
 			}
 			parsed, err := url.Parse(resourceData.Get("url").(string))
 			if err != nil {


### PR DESCRIPTION
Users can optionally set "CODER_URL" if they want to force the
CLI to use a specific endpoint, but this should remain optional.

Forcing this to be set disallows users from using a different
Coder deployment inside of their workspace.