### PR TITLE
feat: Add path-based routing for applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,7 @@ fmt:
 	terraform fmt -recursive
 
 gen:
-	# go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
-	tfplugindocs
+	go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@latest
 
 # Run acceptance tests
 .PHONY: testacc

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -49,11 +49,11 @@ resource "kubernetes_pod" "dev" {
 - `auth` (String) The authentication type the agent will use. Must be one of: "token", "google-instance-identity", "aws-instance-identity", "azure-instance-identity".
 - `dir` (String) The starting directory when a user creates a shell session. Defaults to $HOME.
 - `env` (Map of String) A mapping of environment variables to set inside the workspace.
-- `id` (String) The ID of this resource.
 - `startup_script` (String) A script to run after the agent starts.
 
 ### Read-Only
 
+- `id` (String) The ID of this resource.
 - `init_script` (String) Run this script on startup of an instance to initialize the agent.
 - `token` (String) Set the environment variable "CODER_AGENT_TOKEN" with this token to authenticate an agent.
 

--- a/docs/resources/agent_instance.md
+++ b/docs/resources/agent_instance.md
@@ -37,7 +37,7 @@ resource "coder_agent_instance" "dev" {
 - `agent_id` (String) The "id" property of a "coder_agent" resource to associate with.
 - `instance_id` (String) The instance identifier of a provisioned resource.
 
-### Optional
+### Read-Only
 
 - `id` (String) The ID of this resource.
 

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -29,7 +29,8 @@ resource "coder_app" "code-server" {
   agent_id = coder_agent.dev.id
   name     = "VS Code"
   icon     = data.coder_workspace.me.access_url + "/icons/vscode.svg"
-  target   = "http://localhost:13337"
+  url      = "http://localhost:13337"
+  path     = true
 }
 
 resource "coder_app" "vim" {
@@ -56,10 +57,14 @@ resource "coder_app" "intellij" {
 
 ### Optional
 
-- `command` (String) A command to run in a terminal opening this app. In the web, this will open in a new tab. In the CLI, this will SSH and execute the command. Either "command" or "target" may be specified, but not both.
+- `command` (String) A command to run in a terminal opening this app. In the web, this will open in a new tab. In the CLI, this will SSH and execute the command. Either "command" or "url" may be specified, but not both.
 - `icon` (String) A URL to an icon that will display in the dashboard. View built-in icons here: https://github.com/coder/coder/tree/main/site/static/icons. Use a built-in icon with `data.coder_workspace.me.access_url + "/icons/<path>"`.
-- `id` (String) The ID of this resource.
 - `name` (String) A display name to identify the app.
-- `target` (String) A URL to be proxied to from inside the workspace. Either "command" or "target" may be specified, but not both.
+- `relative_path` (Boolean) Specifies whether the URL will be accessed via a relative path or wildcard. Use if wildcard routing is unavailable.
+- `url` (String) A URL to be proxied to from inside the workspace. Either "command" or "url" may be specified, but not both.
+
+### Read-Only
+
+- `id` (String) The ID of this resource.
 
 

--- a/examples/resources/coder_app/resource.tf
+++ b/examples/resources/coder_app/resource.tf
@@ -14,7 +14,8 @@ resource "coder_app" "code-server" {
   agent_id = coder_agent.dev.id
   name     = "VS Code"
   icon     = data.coder_workspace.me.access_url + "/icons/vscode.svg"
-  target   = "http://localhost:13337"
+  url      = "http://localhost:13337"
+  path     = true
 }
 
 resource "coder_app" "vim" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -260,8 +260,8 @@ func New() *schema.Provider {
 						Type: schema.TypeString,
 						Description: "A command to run in a terminal opening this app. In the web, " +
 							"this will open in a new tab. In the CLI, this will SSH and execute the command. " +
-							"Either \"command\" or \"target\" may be specified, but not both.",
-						ConflictsWith: []string{"target"},
+							"Either \"command\" or \"url\" may be specified, but not both.",
+						ConflictsWith: []string{"url"},
 						Optional:      true,
 						ForceNew:      true,
 					},
@@ -286,10 +286,18 @@ func New() *schema.Provider {
 						ForceNew:    true,
 						Optional:    true,
 					},
-					"target": {
+					"relative_path": {
+						Type: schema.TypeBool,
+						Description: "Specifies whether the URL will be accessed via a relative " +
+							"path or wildcard. Use if wildcard routing is unavailable.",
+						ForceNew:      true,
+						Optional:      true,
+						ConflictsWith: []string{"command"},
+					},
+					"url": {
 						Type: schema.TypeString,
 						Description: "A URL to be proxied to from inside the workspace. " +
-							"Either \"command\" or \"target\" may be specified, but not both.",
+							"Either \"command\" or \"url\" may be specified, but not both.",
 						ForceNew:      true,
 						Optional:      true,
 						ConflictsWith: []string{"command"},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -154,7 +154,8 @@ func TestApp(t *testing.T) {
 					agent_id = coder_agent.dev.id
 					name = "code-server"
 					icon = "builtin:vim"
-					target = "http://localhost:13337"
+					relative_path = true
+					url = "http://localhost:13337"
 				}
 				`,
 			Check: func(state *terraform.State) error {
@@ -166,7 +167,8 @@ func TestApp(t *testing.T) {
 					"agent_id",
 					"name",
 					"icon",
-					"target",
+					"relative_path",
+					"url",
 				} {
 					value := resource.Primary.Attributes[key]
 					t.Logf("%q = %q", key, value)


### PR DESCRIPTION
This adds a `path` parameter that specifies whether the URL
provided will be accessed via the wildcard or relative path.