### PR TITLE
Add data source attribute for owner email address

### DIFF
--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -30,6 +30,8 @@ resource "kubernetes_pod" "dev" {
 - `id` (String) UUID of the workspace.
 - `name` (String) Name of the workspace.
 - `owner` (String) Username of the workspace owner.
+- `owner_name` (String) Display-friendly name of the workspace owner (or their username, if a name is not known).
+- `owner_email` (String) Email address of the workspace owner.
 - `owner_id` (String) UUID of the workspace owner.
 - `start_count` (Number) A computed count based on "transition" state. If "start", count will equal 1.
 - `transition` (String) Either "start" or "stop". Use this to start/stop resources with "count".

--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -30,7 +30,6 @@ resource "kubernetes_pod" "dev" {
 - `id` (String) UUID of the workspace.
 - `name` (String) Name of the workspace.
 - `owner` (String) Username of the workspace owner.
-- `owner_name` (String) Display-friendly name of the workspace owner (or their username, if a name is not known).
 - `owner_email` (String) Email address of the workspace owner.
 - `owner_id` (String) UUID of the workspace owner.
 - `start_count` (Number) A computed count based on "transition" state. If "start", count will equal 1.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -76,12 +76,6 @@ func New() *schema.Provider {
 					}
 					_ = rd.Set("owner", owner)
 
-					ownerName := os.Getenv("CODER_WORKSPACE_OWNER_NAME")
-					if ownerName == "" {
-						ownerName = owner
-					}
-					_ = rd.Set("owner_name", ownerName)
-
 					ownerEmail := os.Getenv("CODER_WORKSPACE_OWNER_EMAIL")
 					_ = rd.Set("owner_email", ownerEmail)
 
@@ -131,11 +125,6 @@ func New() *schema.Provider {
 						Type:        schema.TypeString,
 						Computed:    true,
 						Description: "Username of the workspace owner.",
-					},
-					"owner_name": {
-						Type:        schema.TypeString,
-						Computed:    true,
-						Description: "Name of the workspace owner (e.g. for Git commits) if known, otherwise their username.",
 					},
 					"owner_email": {
 						Type:        schema.TypeString,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -76,11 +76,11 @@ func New() *schema.Provider {
 					}
 					_ = rd.Set("owner", owner)
 
-					/*ownerName := os.Getenv("CODER_WORKSPACE_OWNER_NAME")
+					ownerName := os.Getenv("CODER_WORKSPACE_OWNER_NAME")
 					if ownerName == "" {
 						ownerName = owner
 					}
-					_ = rd.Set("owner_name", ownerName)*/
+					_ = rd.Set("owner_name", ownerName)
 
 					ownerEmail := os.Getenv("CODER_WORKSPACE_OWNER_EMAIL")
 					_ = rd.Set("owner_email", ownerEmail)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -69,31 +69,46 @@ func New() *schema.Provider {
 						count = 1
 					}
 					_ = rd.Set("start_count", count)
+
 					owner := os.Getenv("CODER_WORKSPACE_OWNER")
 					if owner == "" {
 						owner = "default"
 					}
 					_ = rd.Set("owner", owner)
+
+					/*ownerName := os.Getenv("CODER_WORKSPACE_OWNER_NAME")
+					if ownerName == "" {
+						ownerName = owner
+					}
+					_ = rd.Set("owner_name", ownerName)*/
+
+					ownerEmail := os.Getenv("CODER_WORKSPACE_OWNER_EMAIL")
+					_ = rd.Set("owner_email", ownerEmail)
+
 					ownerID := os.Getenv("CODER_WORKSPACE_OWNER_ID")
 					if ownerID == "" {
 						ownerID = uuid.Nil.String()
 					}
 					_ = rd.Set("owner_id", ownerID)
+
 					name := os.Getenv("CODER_WORKSPACE_NAME")
 					if name == "" {
 						name = "default"
 					}
 					rd.Set("name", name)
+
 					id := os.Getenv("CODER_WORKSPACE_ID")
 					if id == "" {
 						id = uuid.NewString()
 					}
 					rd.SetId(id)
+
 					config, valid := i.(config)
 					if !valid {
 						return diag.Errorf("config was unexpected type %q", reflect.TypeOf(i).String())
 					}
 					rd.Set("access_url", config.URL.String())
+
 					return nil
 				},
 				Schema: map[string]*schema.Schema{
@@ -116,6 +131,16 @@ func New() *schema.Provider {
 						Type:        schema.TypeString,
 						Computed:    true,
 						Description: "Username of the workspace owner.",
+					},
+					"owner_name": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Name of the workspace owner (e.g. for Git commits) if known, otherwise their username.",
+					},
+					"owner_email": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "Email address of the workspace owner.",
 					},
 					"owner_id": {
 						Type:        schema.TypeString,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -19,7 +19,10 @@ func TestProvider(t *testing.T) {
 }
 
 func TestWorkspace(t *testing.T) {
-	t.Parallel()
+	t.Setenv("CODER_WORKSPACE_OWNER", "owner123")
+	t.Setenv("CODER_WORKSPACE_OWNER_NAME", "Workspace Owner Jr.")
+	t.Setenv("CODER_WORKSPACE_OWNER_EMAIL", "owner123@example.com")
+
 	resource.Test(t, resource.TestCase{
 		Providers: map[string]*schema.Provider{
 			"coder": provider.New(),
@@ -37,9 +40,14 @@ func TestWorkspace(t *testing.T) {
 				require.Len(t, state.Modules[0].Resources, 1)
 				resource := state.Modules[0].Resources["data.coder_workspace.me"]
 				require.NotNil(t, resource)
-				value := resource.Primary.Attributes["transition"]
+
+				attribs := resource.Primary.Attributes
+				value := attribs["transition"]
 				require.NotNil(t, value)
 				t.Log(value)
+				require.Equal(t, "owner123", attribs["owner"])
+				require.Equal(t, "Workspace Owner Jr.", attribs["owner_name"])
+				require.Equal(t, "owner123@example.com", attribs["owner_email"])
 				return nil
 			},
 		}},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -20,7 +20,6 @@ func TestProvider(t *testing.T) {
 
 func TestWorkspace(t *testing.T) {
 	t.Setenv("CODER_WORKSPACE_OWNER", "owner123")
-	t.Setenv("CODER_WORKSPACE_OWNER_NAME", "Workspace Owner Jr.")
 	t.Setenv("CODER_WORKSPACE_OWNER_EMAIL", "owner123@example.com")
 
 	resource.Test(t, resource.TestCase{
@@ -46,7 +45,6 @@ func TestWorkspace(t *testing.T) {
 				require.NotNil(t, value)
 				t.Log(value)
 				require.Equal(t, "owner123", attribs["owner"])
-				require.Equal(t, "Workspace Owner Jr.", attribs["owner_name"])
 				require.Equal(t, "owner123@example.com", attribs["owner_email"])
 				return nil
 			},


### PR DESCRIPTION
This PR adds a new attribute to the `coder_workspace` data source: `owner_email`, which is populated from the `CODER_WORKSPACE_OWNER_EMAIL` environment variable.