### PR TITLE
feat: Expose access_port on coder_workspace to allow for alternative hosts

### DIFF
--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -26,6 +26,7 @@ resource "kubernetes_pod" "dev" {
 
 ### Read-Only
 
+- `access_port` (Number) The access port of the Coder deployment provisioning this workspace.
 - `access_url` (String) The access URL of the Coder deployment provisioning this workspace.
 - `id` (String) UUID of the workspace.
 - `name` (String) Name of the workspace.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -106,6 +107,19 @@ func New() *schema.Provider {
 					}
 					rd.Set("access_url", config.URL.String())
 
+					rawPort := config.URL.Port()
+					if rawPort == "" {
+						rawPort = "80"
+						if config.URL.Scheme == "https" {
+							rawPort = "443"
+						}
+					}
+					port, err := strconv.Atoi(rawPort)
+					if err != nil {
+						return diag.Errorf("couldn't parse port %q", port)
+					}
+					rd.Set("access_port", port)
+
 					return nil
 				},
 				Schema: map[string]*schema.Schema{
@@ -113,6 +127,11 @@ func New() *schema.Provider {
 						Type:        schema.TypeString,
 						Computed:    true,
 						Description: "The access URL of the Coder deployment provisioning this workspace.",
+					},
+					"access_port": {
+						Type:        schema.TypeInt,
+						Computed:    true,
+						Description: "The access port of the Coder deployment provisioning this workspace.",
 					},
 					"start_count": {
 						Type:        schema.TypeInt,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -31,7 +31,7 @@ func TestWorkspace(t *testing.T) {
 		Steps: []resource.TestStep{{
 			Config: `
 			provider "coder" {
-				url = "https://example.com"
+				url = "https://example.com:8080"
 			}
 			data "coder_workspace" "me" {
 			}`,
@@ -45,6 +45,7 @@ func TestWorkspace(t *testing.T) {
 				value := attribs["transition"]
 				require.NotNil(t, value)
 				t.Log(value)
+				require.Equal(t, "8080", attribs["access_port"])
 				require.Equal(t, "owner123", attribs["owner"])
 				require.Equal(t, "owner123@example.com", attribs["owner_email"])
 				return nil


### PR DESCRIPTION
This allows our Docker template to use a custom host with the correct port.