### PR TITLE
fix: Add custom host for access URL and remove access port

### DIFF
--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -26,7 +26,6 @@ resource "kubernetes_pod" "dev" {
 
 ### Read-Only
 
-- `access_port` (Number) The access port of the Coder deployment provisioning this workspace.
 - `access_url` (String) The access URL of the Coder deployment provisioning this workspace.
 - `id` (String) UUID of the workspace.
 - `name` (String) Name of the workspace.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,8 @@ description: |-
 
 # Coder Provider
 
+-> This works with a closed-alpha of [Coder](https://coder.com). For access, contact [support@coder.com](mailto:support@coder.com).
+
 ## Example
 
 ```terraform
@@ -62,4 +64,5 @@ resource "google_compute_instance" "dev" {
 
 ### Optional
 
+- `host` (String) This overrides the host in the "url" property, but preserve the port.
 - `url` (String) The URL to access Coder.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"reflect"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -41,6 +40,11 @@ func New() *schema.Provider {
 					return nil, nil
 				},
 			},
+			"host": {
+				Type:        schema.TypeString,
+				Description: "This overrides the host in the \"url\" property, but preserve the port.",
+				Optional:    true,
+			},
 		},
 		ConfigureContextFunc: func(c context.Context, resourceData *schema.ResourceData) (interface{}, diag.Diagnostics) {
 			rawURL, ok := resourceData.Get("url").(string)
@@ -53,6 +57,14 @@ func New() *schema.Provider {
 			parsed, err := url.Parse(resourceData.Get("url").(string))
 			if err != nil {
 				return nil, diag.FromErr(err)
+			}
+			rawHost, ok := resourceData.Get("host").(string)
+			if ok {
+				rawPort := parsed.Port()
+				if rawPort != "" && !strings.Contains(rawHost, ":") {
+					rawHost += ":" + rawPort
+				}
+				parsed.Host = rawHost
 			}
 			return config{
 				URL: parsed,
@@ -107,19 +119,6 @@ func New() *schema.Provider {
 					}
 					rd.Set("access_url", config.URL.String())
 
-					rawPort := config.URL.Port()
-					if rawPort == "" {
-						rawPort = "80"
-						if config.URL.Scheme == "https" {
-							rawPort = "443"
-						}
-					}
-					port, err := strconv.Atoi(rawPort)
-					if err != nil {
-						return diag.Errorf("couldn't parse port %q", port)
-					}
-					rd.Set("access_port", port)
-
 					return nil
 				},
 				Schema: map[string]*schema.Schema{
@@ -127,11 +126,6 @@ func New() *schema.Provider {
 						Type:        schema.TypeString,
 						Computed:    true,
 						Description: "The access URL of the Coder deployment provisioning this workspace.",
-					},
-					"access_port": {
-						Type:        schema.TypeInt,
-						Computed:    true,
-						Description: "The access port of the Coder deployment provisioning this workspace.",
 					},
 					"start_count": {
 						Type:        schema.TypeInt,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -32,6 +32,7 @@ func TestWorkspace(t *testing.T) {
 			Config: `
 			provider "coder" {
 				url = "https://example.com:8080"
+				host = "localhost:4334"
 			}
 			data "coder_workspace" "me" {
 			}`,
@@ -45,7 +46,7 @@ func TestWorkspace(t *testing.T) {
 				value := attribs["transition"]
 				require.NotNil(t, value)
 				t.Log(value)
-				require.Equal(t, "8080", attribs["access_port"])
+				require.Equal(t, "https://localhost:4334", attribs["access_url"])
 				require.Equal(t, "owner123", attribs["owner"])
 				require.Equal(t, "owner123@example.com", attribs["owner_email"])
 				return nil


### PR DESCRIPTION
This allows a host override, which is useful for running Docker
containers that need to access the same deployment port, but on
`host.docker.internal` as the hostname.

It also removes access port, which was released a few days ago in hopes of
solving the same problem, but never really did. It doesn't seem likely to
be used yet, so it feels safe to remove.