### PR TITLE
fix: Regenerate agent token on each run

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -55,6 +55,6 @@ resource "kubernetes_pod" "dev" {
 
 - `id` (String) The ID of this resource.
 - `init_script` (String) Run this script on startup of an instance to initialize the agent.
-- `token` (String) Set the environment variable "CODER_AGENT_TOKEN" with this token to authenticate an agent.
+- `token` (String, Sensitive) Set the environment variable "CODER_AGENT_TOKEN" with this token to authenticate an agent.
 
 

--- a/docs/resources/metadata.md
+++ b/docs/resources/metadata.md
@@ -56,6 +56,7 @@ resource "coder_metadata" "pod_info" {
 ### Optional
 
 - `hide` (Boolean) Hide the resource from the UI.
+- `icon` (String) A URL to an icon that will display in the dashboard. View built-in icons here: https://github.com/coder/coder/tree/main/site/static/icon. Use a built-in icon with `data.coder_workspace.me.access_url + "/icons/<path>"`.
 
 ### Read-Only
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -213,7 +213,11 @@ func New() *schema.Provider {
 					}
 					return updateInitScript(resourceData, i)
 				},
-				ReadContext: func(c context.Context, resourceData *schema.ResourceData, i interface{}) diag.Diagnostics {
+				ReadWithoutTimeout: func(c context.Context, resourceData *schema.ResourceData, i interface{}) diag.Diagnostics {
+					err := resourceData.Set("token", uuid.NewString())
+					if err != nil {
+						return diag.FromErr(err)
+					}
 					return updateInitScript(resourceData, i)
 				},
 				DeleteContext: func(c context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics {
@@ -267,6 +271,7 @@ func New() *schema.Provider {
 					},
 					"token": {
 						ForceNew:    true,
+						Sensitive:   true,
 						Description: `Set the environment variable "CODER_AGENT_TOKEN" with this token to authenticate an agent.`,
 						Type:        schema.TypeString,
 						Computed:    true,


### PR DESCRIPTION
This resolves a race condition where an old agent could be updated and connected to before the new agent was registered.