### PR TITLE
chore: set MaxItems to 1 for app healthcheck

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -378,6 +378,7 @@ func New() *schema.Provider {
 						Description:   "HTTP health checking to determine the application readiness.",
 						ForceNew:      true,
 						Optional:      true,
+						MaxItems:      1,
 						ConflictsWith: []string{"command"},
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{


### PR DESCRIPTION
This will protect users from being allow to set the `healthcheck` block more than once. 