### PR TITLE
feat: add slug to app, rename name to display_name

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -27,6 +27,7 @@ EOF
 
 resource "coder_app" "code-server" {
   agent_id  = coder_agent.dev.id
+  slug      = "code-server"
   name      = "VS Code"
   icon      = data.coder_workspace.me.access_url + "/icons/vscode.svg"
   url       = "http://localhost:13337"
@@ -41,6 +42,7 @@ resource "coder_app" "code-server" {
 
 resource "coder_app" "vim" {
   agent_id = coder_agent.dev.id
+  slug     = "vim"
   name     = "Vim"
   icon     = "${data.coder_workspace.me.access_url}/icon/vim.svg"
   command  = "vim"
@@ -49,6 +51,7 @@ resource "coder_app" "vim" {
 resource "coder_app" "intellij" {
   agent_id = coder_agent.dev.id
   icon     = "${data.coder_workspace.me.access_url}/icon/intellij.svg"
+  slug     = "intellij"
   name     = "JetBrains IntelliJ"
   command  = "projector run"
 }
@@ -60,13 +63,15 @@ resource "coder_app" "intellij" {
 ### Required
 
 - `agent_id` (String) The "id" property of a "coder_agent" resource to associate with.
+- `slug` (String) A hostname-friendly name for the app. This is used in URLs to access the app. May contain alphanumerics and hyphens. Cannot start/end with a hyphen or contain two consecutive hyphens.
 
 ### Optional
 
 - `command` (String) A command to run in a terminal opening this app. In the web, this will open in a new tab. In the CLI, this will SSH and execute the command. Either "command" or "url" may be specified, but not both.
+- `display_name` (String) A display name to identify the app. Defaults to the slug.
 - `healthcheck` (Block Set, Max: 1) HTTP health checking to determine the application readiness. (see [below for nested schema](#nestedblock--healthcheck))
 - `icon` (String) A URL to an icon that will display in the dashboard. View built-in icons here: https://github.com/coder/coder/tree/main/site/static/icons. Use a built-in icon with `data.coder_workspace.me.access_url + "/icons/<path>"`.
-- `name` (String) A display name to identify the app.
+- `name` (String, Deprecated) A display name to identify the app.
 - `relative_path` (Boolean, Deprecated) Specifies whether the URL will be accessed via a relative path or wildcard. Use if wildcard routing is unavailable. Defaults to true.
 - `share` (String) Determines the "level" which the application is shared at. Valid levels are "owner" (default), "authenticated" and "public". Level "owner" disables sharing on the app, so only the workspace owner can access it. Level "authenticated" shares the app with all authenticated users. Level "public" shares it with any user, including unauthenticated users. Permitted application sharing levels can be configured site-wide via a flag on `coder server` (Enterprise only).
 - `subdomain` (Boolean) Determines whether the app will be accessed via it's own subdomain or whether it will be accessed via a path on Coder. If wildcards have not been setup by the administrator then apps with "subdomain" set to true will not be accessible. Defaults to false.

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -26,13 +26,13 @@ EOF
 }
 
 resource "coder_app" "code-server" {
-  agent_id  = coder_agent.dev.id
-  slug      = "code-server"
-  name      = "VS Code"
-  icon      = data.coder_workspace.me.access_url + "/icons/vscode.svg"
-  url       = "http://localhost:13337"
-  share     = "owner"
-  subdomain = false
+  agent_id     = coder_agent.dev.id
+  slug         = "code-server"
+  display_name = "VS Code"
+  icon         = data.coder_workspace.me.access_url + "/icons/vscode.svg"
+  url          = "http://localhost:13337"
+  share        = "owner"
+  subdomain    = false
   healthcheck {
     url       = "http://localhost:13337/healthz"
     interval  = 5
@@ -41,19 +41,19 @@ resource "coder_app" "code-server" {
 }
 
 resource "coder_app" "vim" {
-  agent_id = coder_agent.dev.id
-  slug     = "vim"
-  name     = "Vim"
-  icon     = "${data.coder_workspace.me.access_url}/icon/vim.svg"
-  command  = "vim"
+  agent_id     = coder_agent.dev.id
+  slug         = "vim"
+  display_name = "Vim"
+  icon         = "${data.coder_workspace.me.access_url}/icon/vim.svg"
+  command      = "vim"
 }
 
 resource "coder_app" "intellij" {
-  agent_id = coder_agent.dev.id
-  icon     = "${data.coder_workspace.me.access_url}/icon/intellij.svg"
-  slug     = "intellij"
-  name     = "JetBrains IntelliJ"
-  command  = "projector run"
+  agent_id     = coder_agent.dev.id
+  icon         = "${data.coder_workspace.me.access_url}/icon/intellij.svg"
+  slug         = "intellij"
+  display_name = "JetBrains IntelliJ"
+  command      = "projector run"
 }
 ```
 

--- a/examples/resources/coder_app/resource.tf
+++ b/examples/resources/coder_app/resource.tf
@@ -12,6 +12,7 @@ EOF
 
 resource "coder_app" "code-server" {
   agent_id  = coder_agent.dev.id
+  slug      = "code-server"
   name      = "VS Code"
   icon      = data.coder_workspace.me.access_url + "/icons/vscode.svg"
   url       = "http://localhost:13337"
@@ -26,6 +27,7 @@ resource "coder_app" "code-server" {
 
 resource "coder_app" "vim" {
   agent_id = coder_agent.dev.id
+  slug     = "vim"
   name     = "Vim"
   icon     = "${data.coder_workspace.me.access_url}/icon/vim.svg"
   command  = "vim"
@@ -34,6 +36,7 @@ resource "coder_app" "vim" {
 resource "coder_app" "intellij" {
   agent_id = coder_agent.dev.id
   icon     = "${data.coder_workspace.me.access_url}/icon/intellij.svg"
+  slug     = "intellij"
   name     = "JetBrains IntelliJ"
   command  = "projector run"
 }

--- a/examples/resources/coder_app/resource.tf
+++ b/examples/resources/coder_app/resource.tf
@@ -11,13 +11,13 @@ EOF
 }
 
 resource "coder_app" "code-server" {
-  agent_id  = coder_agent.dev.id
-  slug      = "code-server"
-  name      = "VS Code"
-  icon      = data.coder_workspace.me.access_url + "/icons/vscode.svg"
-  url       = "http://localhost:13337"
-  share     = "owner"
-  subdomain = false
+  agent_id     = coder_agent.dev.id
+  slug         = "code-server"
+  display_name = "VS Code"
+  icon         = data.coder_workspace.me.access_url + "/icons/vscode.svg"
+  url          = "http://localhost:13337"
+  share        = "owner"
+  subdomain    = false
   healthcheck {
     url       = "http://localhost:13337/healthz"
     interval  = 5
@@ -26,17 +26,17 @@ resource "coder_app" "code-server" {
 }
 
 resource "coder_app" "vim" {
-  agent_id = coder_agent.dev.id
-  slug     = "vim"
-  name     = "Vim"
-  icon     = "${data.coder_workspace.me.access_url}/icon/vim.svg"
-  command  = "vim"
+  agent_id     = coder_agent.dev.id
+  slug         = "vim"
+  display_name = "Vim"
+  icon         = "${data.coder_workspace.me.access_url}/icon/vim.svg"
+  command      = "vim"
 }
 
 resource "coder_app" "intellij" {
-  agent_id = coder_agent.dev.id
-  icon     = "${data.coder_workspace.me.access_url}/icon/intellij.svg"
-  slug     = "intellij"
-  name     = "JetBrains IntelliJ"
-  command  = "projector run"
+  agent_id     = coder_agent.dev.id
+  icon         = "${data.coder_workspace.me.access_url}/icon/intellij.svg"
+  slug         = "intellij"
+  display_name = "JetBrains IntelliJ"
+  command      = "projector run"
 }

--- a/provider/app_test.go
+++ b/provider/app_test.go
@@ -33,7 +33,8 @@ func TestApp(t *testing.T) {
 				}
 				resource "coder_app" "code-server" {
 					agent_id = coder_agent.dev.id
-					name = "code-server"
+					slug = "code-server"
+					display_name = "code-server"
 					icon = "builtin:vim"
 					subdomain = false
 					url = "http://localhost:13337"
@@ -51,7 +52,8 @@ func TestApp(t *testing.T) {
 					require.NotNil(t, resource)
 					for _, key := range []string{
 						"agent_id",
-						"name",
+						"slug",
+						"display_name",
 						"icon",
 						"subdomain",
 						// Should be set by default even though it isn't
@@ -128,7 +130,8 @@ func TestApp(t *testing.T) {
 				}
 				resource "coder_app" "code-server" {
 					agent_id = coder_agent.dev.id
-					name = "code-server"
+					slug = "code-server"
+					display_name = "code-server"
 					icon = "builtin:vim"
 					url = "http://localhost:13337"
 					%s


### PR DESCRIPTION
- Adds new required `slug` property to `coder_app`
    - Must match a regex that ensures the slug is hostname-safe
- Adds new property `display_name` to `coder_app`
- Deprecates `name` in favor of `display_name` in `coder_app`

coder/coder#4573