### PR TITLE
Add cost field to resource_metadata

### DIFF
--- a/docs/resources/metadata.md
+++ b/docs/resources/metadata.md
@@ -28,6 +28,8 @@ resource "tls_private_key" "example_key_pair" {
 resource "coder_metadata" "pod_info" {
   count       = data.coder_workspace.me.start_count
   resource_id = kubernetes_pod.dev[0].id
+  # (Enterprise-only) this resource consumes 200 quota units
+  cost = 200
   item {
     key   = "description"
     value = "This description will show up in the Coder dashboard."
@@ -55,6 +57,7 @@ resource "coder_metadata" "pod_info" {
 
 ### Optional
 
+- `cost` (Number) (Enterprise) The amount of quota units this resource consumes
 - `hide` (Boolean) Hide the resource from the UI.
 - `icon` (String) A URL to an icon that will display in the dashboard. View built-in icons here: https://github.com/coder/coder/tree/main/site/static/icon. Use a built-in icon with `data.coder_workspace.me.access_url + "/icons/<path>"`.
 

--- a/examples/resources/coder_metadata/resource.tf
+++ b/examples/resources/coder_metadata/resource.tf
@@ -13,6 +13,8 @@ resource "tls_private_key" "example_key_pair" {
 resource "coder_metadata" "pod_info" {
   count       = data.coder_workspace.me.start_count
   resource_id = kubernetes_pod.dev[0].id
+  # (Enterprise-only) this resource consumes 200 quota units
+  cost = 200
   item {
     key   = "description"
     value = "This description will show up in the Coder dashboard."

--- a/provider/metadata.go
+++ b/provider/metadata.go
@@ -61,6 +61,12 @@ func metadataResource() *schema.Resource {
 					return nil, nil
 				},
 			},
+			"cost": {
+				Type:        schema.TypeInt,
+				Description: "(Enterprise) The amount of quota units this resource consumes",
+				ForceNew:    true,
+				Optional:    true,
+			},
 			"item": {
 				Type:        schema.TypeList,
 				Description: "Each \"item\" block defines a single metadata item consisting of a key/value pair.",

--- a/provider/metadata_test.go
+++ b/provider/metadata_test.go
@@ -31,6 +31,7 @@ func TestMetadata(t *testing.T) {
 					resource_id = coder_agent.dev.id
 					hide = true
 					icon = "/icons/storage.svg"
+					cost = 200
 					item {
 						key = "foo"
 						value = "bar"
@@ -65,6 +66,7 @@ func TestMetadata(t *testing.T) {
 					"resource_id":      agent.Primary.Attributes["id"],
 					"hide":             "true",
 					"icon":             "/icons/storage.svg",
+					"cost":             "200",
 					"item.#":           "5",
 					"item.0.key":       "foo",
 					"item.0.value":     "bar",


### PR DESCRIPTION
Iffy on whether to call it `quota_cost` or `cost`. I'm leaning `cost` because it's shorter, and we may use these fields to show analytics even when quotas are disabled.