### PR TITLE
feat: Add motd_file to coder_agent

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -50,6 +50,7 @@ resource "kubernetes_pod" "dev" {
 - `connection_timeout` (Number) Time in seconds until the agent is marked as timed out when a connection with the server cannot be established.
 - `dir` (String) The starting directory when a user creates a shell session. Defaults to $HOME.
 - `env` (Map of String) A mapping of environment variables to set inside the workspace.
+- `motd_file` (String) The path to a file within the workspace containing a message to display to users when they login via SSH. A typical value would be /etc/motd.
 - `startup_script` (String) A script to run after the agent starts.
 - `troubleshooting_url` (String) A URL to a document with instructions for troubleshooting problems with the agent.
 

--- a/provider/agent.go
+++ b/provider/agent.go
@@ -101,6 +101,12 @@ func agentResource() *schema.Resource {
 				Optional:    true,
 				Description: "A URL to a document with instructions for troubleshooting problems with the agent.",
 			},
+			"motd_file": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "The path to a file within the workspace containing a message to display to users when they login via SSH. A typical value would be /etc/motd.",
+			},
 		},
 	}
 }

--- a/provider/agent_test.go
+++ b/provider/agent_test.go
@@ -32,6 +32,7 @@ func TestAgent(t *testing.T) {
 					}
 					startup_script = "echo test"
 					troubleshooting_url = "https://example.com/troubleshoot"
+					motd_file = "/etc/motd"
 				}
 				`,
 			Check: func(state *terraform.State) error {
@@ -49,6 +50,7 @@ func TestAgent(t *testing.T) {
 					"startup_script",
 					"connection_timeout",
 					"troubleshooting_url",
+					"motd_file",
 				} {
 					value := resource.Primary.Attributes[key]
 					t.Logf("%q = %q", key, value)


### PR DESCRIPTION
This change allows us to enable better feature parity with OpenSSH by
being able to display a message when users login. This is useful for
template authors who want to inform their users about changes or
reporting about the state of the workspace.

I did consider if we should turn this into a script, like:

```tf
motd_script = <<-EOS
	cat /etc/motd
EOS
```

But while this is flexible, it raises questions like how often should we run it, sould we run it on every query, what if it takes a long time to execute, etc. For this reason we're sticking with the simplicity of a single file and making it the responsibility of the author to start a service to update its content, where required.

This feature could be expanded to support things like VSCode/JetBrains extensions as well, to surface the message not just via SSH, but these clients as well.