### PR TITLE
feat: Add support for shutdown_script

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -51,6 +51,7 @@ resource "kubernetes_pod" "dev" {
 - `dir` (String) The starting directory when a user creates a shell session. Defaults to $HOME.
 - `env` (Map of String) A mapping of environment variables to set inside the workspace.
 - `motd_file` (String) The path to a file within the workspace containing a message to display to users when they login via SSH. A typical value would be /etc/motd.
+- `shutdown_script` (String) A script to run before the agent is stopped.
 - `startup_script` (String) A script to run after the agent starts.
 - `troubleshooting_url` (String) A URL to a document with instructions for troubleshooting problems with the agent.
 

--- a/provider/agent.go
+++ b/provider/agent.go
@@ -107,6 +107,12 @@ func agentResource() *schema.Resource {
 				Optional:    true,
 				Description: "The path to a file within the workspace containing a message to display to users when they login via SSH. A typical value would be /etc/motd.",
 			},
+			"shutdown_script": {
+				ForceNew:    true,
+				Description: "A script to run before the agent is stopped.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 		},
 	}
 }

--- a/provider/agent_test.go
+++ b/provider/agent_test.go
@@ -33,6 +33,7 @@ func TestAgent(t *testing.T) {
 					startup_script = "echo test"
 					troubleshooting_url = "https://example.com/troubleshoot"
 					motd_file = "/etc/motd"
+					shutdown_script = "echo bye bye"
 				}
 				`,
 			Check: func(state *terraform.State) error {
@@ -51,6 +52,7 @@ func TestAgent(t *testing.T) {
 					"connection_timeout",
 					"troubleshooting_url",
 					"motd_file",
+					"shutdown_script",
 				} {
 					value := resource.Primary.Attributes[key]
 					t.Logf("%q = %q", key, value)


### PR DESCRIPTION
Issue: https://github.com/coder/coder/issues/4677

This PR introduces a new parameter - the shutdown script. The script is intended to be executed before the agent is stopped, before the [networking is shut down](https://github.com/coder/coder/blob/main/agent/agent.go#L930).