### PR TITLE
feat: use validation error while parsing `coder_parameter`

### DIFF
--- a/examples/resources/coder_app/resource.tf
+++ b/examples/resources/coder_app/resource.tf
@@ -14,7 +14,7 @@ resource "coder_app" "code-server" {
   agent_id     = coder_agent.dev.id
   slug         = "code-server"
   display_name = "VS Code"
-  icon         = data.coder_workspace.me.access_url + "/icon/code.svg"
+  icon         = "${data.coder_workspace.me.access_url}/icon/code.svg"
   url          = "http://localhost:13337"
   share        = "owner"
   subdomain    = false

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -28,16 +28,19 @@ data "coder_parameter" "is_public_instance" {
   name = "Is public instance?"
   icon = "/icon/docker.svg"
   type = "bool"
+  default = false
 }
 
 data "coder_parameter" "cores" {
   name = "CPU Cores"
   icon = "/icon/"
+  default = 3
 }
 
 data "coder_parameter" "disk_size" {
   name = "Disk Size"
   type = "number"
+  default = "9"
   validation {
     # This can apply to number and string types.
     min = 0

--- a/provider/examples_test.go
+++ b/provider/examples_test.go
@@ -1,0 +1,33 @@
+package provider_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/coder/terraform-provider-coder/provider"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExamples(t *testing.T) {
+	t.Parallel()
+
+	t.Run("coder_parameter", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			Providers: map[string]*schema.Provider{
+				"coder": provider.New(),
+			},
+			IsUnitTest: true,
+			Steps: []resource.TestStep{{
+				Config: mustReadFile(t, "../examples/resources/coder_parameter/resource.tf"),
+			}},
+		})
+	})
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(content)
+}

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -300,12 +300,12 @@ func (v *Validation) Valid(typ, value string) error {
 		if err != nil {
 			return fmt.Errorf("compile regex %q: %s", regex, err)
 		}
-		matched := regex.MatchString(value)
-		if !matched {
-			return fmt.Errorf("value %q does not match %q", value, regex)
-		}
 		if v.Error == "" {
 			return fmt.Errorf("an error must be specified with a regex validation")
+		}
+		matched := regex.MatchString(value)
+		if !matched {
+			return fmt.Errorf("%s (value %q does not match %q)", v.Error, value, regex)
 		}
 	case "number":
 		num, err := strconv.Atoi(value)

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -267,7 +267,8 @@ func TestValueValidatesType(t *testing.T) {
 		Name,
 		Type,
 		Value,
-		Regex string
+		Regex,
+		RegexError string
 		Min,
 		Max int
 		Error *regexp.Regexp
@@ -312,6 +313,13 @@ func TestValueValidatesType(t *testing.T) {
 		Type:  "bool",
 		Value: "cat",
 		Error: regexp.MustCompile("boolean value can be either"),
+	}, {
+		Name:       "BadStringWithRegex",
+		Type:       "string",
+		Regex:      "banana",
+		RegexError: "bad fruit",
+		Value:      "apple",
+		Error:      regexp.MustCompile(`bad fruit`),
 	}} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
@@ -320,6 +328,7 @@ func TestValueValidatesType(t *testing.T) {
 				Min:   tc.Min,
 				Max:   tc.Max,
 				Regex: tc.Regex,
+				Error: tc.RegexError,
 			}
 			err := v.Valid(tc.Type, tc.Value)
 			if tc.Error != nil {


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/5574

Changes:
* fix: typo in `coder_app` example
* fix: invalid parameter definition in `coder_parameter` example
* feat: show `Validation.Error` when regexp doesn't match
* feat: test `coder_parameter` example