### PR TITLE
test: parameter description contains Markdown

### DIFF
--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -17,9 +17,8 @@ data "coder_parameter" "example" {
 
 data "coder_parameter" "ami" {
   name = "Machine Image"
-  description = "Provide the machine image."
-  description_markdown = <<-EOT
-    # Select the machine image
+  description = <<-EOT
+    # Provide the machine image
     See the [registry](https://container.registry.blah/namespace) for options.
     EOT
   option {

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -17,6 +17,11 @@ data "coder_parameter" "example" {
 
 data "coder_parameter" "ami" {
   name = "Machine Image"
+  description = "Provide the machine image."
+  description_markdown = <<EOT
+# Select the machine image
+See the [registry](https://container.registry.blah/namespace) for options.
+  EOT
   option {
     value = "ami-xxxxxxxx"
     name  = "Ubuntu"
@@ -26,14 +31,15 @@ data "coder_parameter" "ami" {
 
 data "coder_parameter" "is_public_instance" {
   name = "Is public instance?"
-  icon = "/icon/docker.svg"
   type = "bool"
+  icon = "/icon/docker.svg"
   default = false
 }
 
 data "coder_parameter" "cores" {
   name = "CPU Cores"
-  icon = "/icon/"
+  type = "number"
+  icon = "/icon/cpu.svg"
   default = 3
 }
 
@@ -50,7 +56,7 @@ data "coder_parameter" "disk_size" {
 }
 
 data "coder_parameter" "cat_lives" {
-  name = "Cat Live"
+  name = "Cat Lives"
   type = "number"
   default = "9"
   validation {

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -18,10 +18,10 @@ data "coder_parameter" "example" {
 data "coder_parameter" "ami" {
   name = "Machine Image"
   description = "Provide the machine image."
-  description_markdown = <<EOT
-# Select the machine image
-See the [registry](https://container.registry.blah/namespace) for options.
-  EOT
+  description_markdown = <<-EOT
+    # Select the machine image
+    See the [registry](https://container.registry.blah/namespace) for options.
+    EOT
   option {
     value = "ami-xxxxxxxx"
     name  = "Ubuntu"

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -39,16 +39,15 @@ const (
 )
 
 type Parameter struct {
-	Value               string
-	Name                string
-	Description         string
-	DescriptionMarkdown string
-	Type                string
-	Mutable             bool
-	Default             string
-	Icon                string
-	Option              []Option
-	Validation          []Validation
+	Value       string
+	Name        string
+	Description string
+	Type        string
+	Mutable     bool
+	Default     string
+	Icon        string
+	Option      []Option
+	Validation  []Validation
 }
 
 func parameterDataSource() *schema.Resource {
@@ -59,27 +58,25 @@ func parameterDataSource() *schema.Resource {
 
 			var parameter Parameter
 			err := mapstructure.Decode(struct {
-				Value               interface{}
-				Name                interface{}
-				Description         interface{}
-				DescriptionMarkdown interface{}
-				Type                interface{}
-				Mutable             interface{}
-				Default             interface{}
-				Icon                interface{}
-				Option              interface{}
-				Validation          interface{}
+				Value       interface{}
+				Name        interface{}
+				Description interface{}
+				Type        interface{}
+				Mutable     interface{}
+				Default     interface{}
+				Icon        interface{}
+				Option      interface{}
+				Validation  interface{}
 			}{
-				Value:               rd.Get("value"),
-				Name:                rd.Get("name"),
-				Description:         rd.Get("description"),
-				DescriptionMarkdown: rd.Get("description_markdown"),
-				Type:                rd.Get("type"),
-				Mutable:             rd.Get("mutable"),
-				Default:             rd.Get("default"),
-				Icon:                rd.Get("icon"),
-				Option:              rd.Get("option"),
-				Validation:          rd.Get("validation"),
+				Value:       rd.Get("value"),
+				Name:        rd.Get("name"),
+				Description: rd.Get("description"),
+				Type:        rd.Get("type"),
+				Mutable:     rd.Get("mutable"),
+				Default:     rd.Get("default"),
+				Icon:        rd.Get("icon"),
+				Option:      rd.Get("option"),
+				Validation:  rd.Get("validation"),
 			}, &parameter)
 			if err != nil {
 				return diag.Errorf("decode parameter: %s", err)
@@ -144,11 +141,6 @@ func parameterDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Describe what this parameter does.",
-			},
-			"description_markdown": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Alternative description with Markdown tags.",
 			},
 			"type": {
 				Type:         schema.TypeString,

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -39,15 +39,16 @@ const (
 )
 
 type Parameter struct {
-	Value       string
-	Name        string
-	Description string
-	Type        string
-	Mutable     bool
-	Default     string
-	Icon        string
-	Option      []Option
-	Validation  []Validation
+	Value               string
+	Name                string
+	Description         string
+	DescriptionMarkdown string
+	Type                string
+	Mutable             bool
+	Default             string
+	Icon                string
+	Option              []Option
+	Validation          []Validation
 }
 
 func parameterDataSource() *schema.Resource {
@@ -58,25 +59,27 @@ func parameterDataSource() *schema.Resource {
 
 			var parameter Parameter
 			err := mapstructure.Decode(struct {
-				Value       interface{}
-				Name        interface{}
-				Description interface{}
-				Type        interface{}
-				Mutable     interface{}
-				Default     interface{}
-				Icon        interface{}
-				Option      interface{}
-				Validation  interface{}
+				Value               interface{}
+				Name                interface{}
+				Description         interface{}
+				DescriptionMarkdown interface{}
+				Type                interface{}
+				Mutable             interface{}
+				Default             interface{}
+				Icon                interface{}
+				Option              interface{}
+				Validation          interface{}
 			}{
-				Value:       rd.Get("value"),
-				Name:        rd.Get("name"),
-				Description: rd.Get("description"),
-				Type:        rd.Get("type"),
-				Mutable:     rd.Get("mutable"),
-				Default:     rd.Get("default"),
-				Icon:        rd.Get("icon"),
-				Option:      rd.Get("option"),
-				Validation:  rd.Get("validation"),
+				Value:               rd.Get("value"),
+				Name:                rd.Get("name"),
+				Description:         rd.Get("description"),
+				DescriptionMarkdown: rd.Get("description_markdown"),
+				Type:                rd.Get("type"),
+				Mutable:             rd.Get("mutable"),
+				Default:             rd.Get("default"),
+				Icon:                rd.Get("icon"),
+				Option:              rd.Get("option"),
+				Validation:          rd.Get("validation"),
 			}, &parameter)
 			if err != nil {
 				return diag.Errorf("decode parameter: %s", err)
@@ -141,6 +144,11 @@ func parameterDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Describe what this parameter does.",
+			},
+			"description_markdown": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Alternative description with Markdown tags.",
 			},
 			"type": {
 				Type:         schema.TypeString,

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -24,8 +24,7 @@ func TestParameter(t *testing.T) {
 data "coder_parameter" "region" {
 	name = "Region"
 	type = "string"
-	description = "Some option!"
-	description_markdown = <<-EOT
+	description = <<-EOT
 		# Select the machine image
 		See the [registry](https://container.registry.blah/namespace) for options.
 		EOT
@@ -50,8 +49,7 @@ data "coder_parameter" "region" {
 			for key, value := range map[string]interface{}{
 				"name":                 "Region",
 				"type":                 "string",
-				"description":          "Some option!",
-				"description_markdown": "# Select the machine image\nSee the [registry](https://container.registry.blah/namespace) for options.\n",
+				"description":          "# Select the machine image\nSee the [registry](https://container.registry.blah/namespace) for options.\n",
 				"mutable":              "true",
 				"icon":                 "/icon/region.svg",
 				"option.0.name":        "US Central",

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -25,10 +25,10 @@ data "coder_parameter" "region" {
 	name = "Region"
 	type = "string"
 	description = "Some option!"
-	description_markdown = <<EOT
-# Select the machine image
-See the [registry](https://container.registry.blah/namespace) for options.
-EOT
+	description_markdown = <<-EOT
+		# Select the machine image
+		See the [registry](https://container.registry.blah/namespace) for options.
+		EOT
 	mutable = true
 	icon = "/icon/region.svg"
 	option {

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -25,6 +25,10 @@ data "coder_parameter" "region" {
 	name = "Region"
 	type = "string"
 	description = "Some option!"
+	description_markdown = <<EOT
+# Select the machine image
+See the [registry](https://container.registry.blah/namespace) for options.
+EOT
 	mutable = true
 	icon = "/icon/region.svg"
 	option {
@@ -47,6 +51,7 @@ data "coder_parameter" "region" {
 				"name":                 "Region",
 				"type":                 "string",
 				"description":          "Some option!",
+				"description_markdown": "# Select the machine image\nSee the [registry](https://container.registry.blah/namespace) for options.\n",
 				"mutable":              "true",
 				"icon":                 "/icon/region.svg",
 				"option.0.name":        "US Central",


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/5931

This PR improves tests to present that the Markdown format is acceptable for the parameter description.

~This PR introduces a new Markdown property to render rich descriptions, with Markdown tags included (see example).~

~Comment:
I admit that I wanted to use the `description` and then strip Markdown tags from descriptions in CLI, but when I looked at the [logic](https://github.com/stiang/remove-markdown/blob/main/index.js) required to perform this (rewritten to Go), I decided to KISS and use a dedicated property, that is only processed by the site.~