### PR TITLE
feat: Add flag to enable managed variables

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,4 +62,5 @@ resource "google_compute_instance" "dev" {
 
 ### Optional
 
+- `feature_use_managed_variables` (Boolean) Feature: use managed Terraform variables. If disabled, Terraform variables will be included in legacy Parameter Schema.
 - `url` (String) The URL to access Coder.

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -1,3 +1,7 @@
+provider "coder" {
+  feature_use_managed_variables = true
+}
+
 data "coder_parameter" "example" {
   name        = "Region"
   description = "Specify a region to place your workspace."

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -37,7 +37,7 @@ func New() *schema.Provider {
 			},
 			"feature_use_managed_variables": {
 				Type:        schema.TypeBool,
-				Description: "Feature: user managed Terraform variables. If disabled, Terraform variables will be included in legacy Parameter Schema.",
+				Description: "Feature: use managed Terraform variables. If disabled, Terraform variables will be included in legacy Parameter Schema.",
 				Optional:    true,
 			},
 		},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -35,6 +35,11 @@ func New() *schema.Provider {
 					return nil, nil
 				},
 			},
+			"feature_use_managed_variables": {
+				Type:        schema.TypeBool,
+				Description: "Feature: user managed Terraform variables. If disabled, Terraform variables will be included in legacy Parameter Schema.",
+				Optional:    true,
+			},
 		},
 		ConfigureContextFunc: func(c context.Context, resourceData *schema.ResourceData) (interface{}, diag.Diagnostics) {
 			rawURL, ok := resourceData.Get("url").(string)


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/5980

This PR introduces a feature flag to enable managed template-wide variables. The flag is required to select the processing strategy - either use legacy Parameter Schema or new template variables ([under development](https://github.com/coder/coder/pull/6134)).

Comment:
I had to add this flag as `terraform` complains:

```
> Upload "mtojek/docker-rich"? (yes/no) yes
✔ Queued [571ms]
✔ Setting up [1ms]
✔ Parsing template parameters [60ms]
⧗  Detecting persistent resources
  Terraform 1.2.6
  Error: Unsupported argument
  An argument named "feature_use_managed_variables" is not expected here.
✔ Detecting persistent resources [7623ms]
✘ Cleaning Up [110ms]
```

The idea is to remove the flag as the new strategy will be enabled by default.