### PR TITLE
feat: Enable default value for rich parameter options

### DIFF
--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -7,6 +7,7 @@ data "coder_parameter" "example" {
   description = "Specify a region to place your workspace."
   mutable     = false
   type        = "string"
+  default     = "asia-central1-a"
   option {
     value = "us-central1-a"
     name  = "US Central"

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -122,6 +122,13 @@ func parameterDataSource() *schema.Resource {
 					values[option.Value] = nil
 					names[option.Name] = nil
 				}
+
+				if parameter.Default != "" {
+					_, defaultIsValid := values[parameter.Default]
+					if !defaultIsValid {
+						return diag.Errorf("default value %q must be defined as one of options", parameter.Default)
+					}
+				}
 			}
 
 			return nil
@@ -156,10 +163,9 @@ func parameterDataSource() *schema.Resource {
 				Description: "Whether this value can be changed after workspace creation. This can be destructive for values like region, so use with caution!",
 			},
 			"default": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Description:  "A default value for the parameter.",
-				ExactlyOneOf: []string{"option"},
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A default value for the parameter.",
 			},
 			"icon": {
 				Type: schema.TypeString,

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -174,7 +174,38 @@ data "coder_parameter" "region" {
 			}
 		},
 	}, {
-		Name: "DefaultWithOption",
+		Name: "ValidDefaultWithOptions",
+		Config: `
+data "coder_parameter" "region" {
+	name = "Region"
+	type = "string"
+	default = "2"
+	option {
+		name = "1"
+		value = "1"
+		icon = "/icon/code.svg"
+		description = "Something!"
+	}
+	option {
+		name = "2"
+		value = "2"
+	}
+}
+`,
+		Check: func(state *terraform.ResourceState) {
+			for key, expected := range map[string]string{
+				"name":                 "Region",
+				"option.#":             "2",
+				"option.0.name":        "1",
+				"option.0.value":       "1",
+				"option.0.icon":        "/icon/code.svg",
+				"option.0.description": "Something!",
+			} {
+				require.Equal(t, expected, state.Primary.Attributes[key])
+			}
+		},
+	}, {
+		Name: "InvalidDefaultWithOption",
 		Config: `
 data "coder_parameter" "region" {
 	name = "Region"
@@ -189,7 +220,7 @@ data "coder_parameter" "region" {
 	}
 }
 `,
-		ExpectError: regexp.MustCompile("Invalid combination of arguments"),
+		ExpectError: regexp.MustCompile("must be defined as one of options"),
 	}, {
 		Name: "SingleOption",
 		Config: `


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6328

This PR enables the `default` value for rich parameters with predefined options.