### PR TITLE
feat: mark coder_parameter as optional

### DIFF
--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -32,7 +32,7 @@ Use this data source to configure editable options for workspaces.
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `required` (Boolean) Whether this value is required.
+- `optional` (Boolean) Whether this value is optional.
 - `value` (String) The output value of the parameter.
 
 <a id="nestedblock--option"></a>

--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -32,6 +32,7 @@ Use this data source to configure editable options for workspaces.
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `required` (Boolean) Whether this value is required.
 - `value` (String) The output value of the parameter.
 
 <a id="nestedblock--option"></a>

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -70,3 +70,8 @@ data "coder_parameter" "cat_lives" {
     monotonic = "decreasing"
   }
 }
+
+data "coder_parameter" "fairy_tale" {
+  name = "Fairy Tale"
+  type = "string"
+}

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -80,6 +80,9 @@ func parameterDataSource() *schema.Resource {
 				Option:      rd.Get("option"),
 				Validation:  rd.Get("validation"),
 				Required: func() bool {
+					// This hack allows for checking if the "default" field is present in the .tf file.
+					// If "default" is missing or is "null", then it means that this field is required,
+					// and user must provide a value for it.
 					val := rd.GetRawConfig().AsValueMap()["default"].IsNull()
 					rd.Set("required", val)
 					return val

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -48,6 +48,7 @@ type Parameter struct {
 	Icon        string
 	Option      []Option
 	Validation  []Validation
+	Required    bool
 }
 
 func parameterDataSource() *schema.Resource {
@@ -67,6 +68,7 @@ func parameterDataSource() *schema.Resource {
 				Icon        interface{}
 				Option      interface{}
 				Validation  interface{}
+				Required    interface{}
 			}{
 				Value:       rd.Get("value"),
 				Name:        rd.Get("name"),
@@ -77,6 +79,11 @@ func parameterDataSource() *schema.Resource {
 				Icon:        rd.Get("icon"),
 				Option:      rd.Get("option"),
 				Validation:  rd.Get("validation"),
+				Required: func() bool {
+					val := rd.GetRawConfig().AsValueMap()["default"].IsNull()
+					rd.Set("required", val)
+					return val
+				}(),
 			}, &parameter)
 			if err != nil {
 				return diag.Errorf("decode parameter: %s", err)
@@ -130,7 +137,6 @@ func parameterDataSource() *schema.Resource {
 					}
 				}
 			}
-
 			return nil
 		},
 		Schema: map[string]*schema.Schema{
@@ -267,6 +273,11 @@ func parameterDataSource() *schema.Resource {
 						},
 					},
 				},
+			},
+			"required": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether this value is required.",
 			},
 		},
 	}

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -48,7 +48,7 @@ type Parameter struct {
 	Icon        string
 	Option      []Option
 	Validation  []Validation
-	Required    bool
+	Optional    bool
 }
 
 func parameterDataSource() *schema.Resource {
@@ -68,7 +68,7 @@ func parameterDataSource() *schema.Resource {
 				Icon        interface{}
 				Option      interface{}
 				Validation  interface{}
-				Required    interface{}
+				Optional    interface{}
 			}{
 				Value:       rd.Get("value"),
 				Name:        rd.Get("name"),
@@ -79,12 +79,12 @@ func parameterDataSource() *schema.Resource {
 				Icon:        rd.Get("icon"),
 				Option:      rd.Get("option"),
 				Validation:  rd.Get("validation"),
-				Required: func() bool {
+				Optional: func() bool {
 					// This hack allows for checking if the "default" field is present in the .tf file.
 					// If "default" is missing or is "null", then it means that this field is required,
 					// and user must provide a value for it.
-					val := rd.GetRawConfig().AsValueMap()["default"].IsNull()
-					rd.Set("required", val)
+					val := !rd.GetRawConfig().AsValueMap()["default"].IsNull()
+					rd.Set("optional", val)
 					return val
 				}(),
 			}, &parameter)
@@ -277,10 +277,10 @@ func parameterDataSource() *schema.Resource {
 					},
 				},
 			},
-			"required": {
+			"optional": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Whether this value is required.",
+				Description: "Whether this value is optional.",
 			},
 		},
 	}

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -277,13 +277,13 @@ data "coder_parameter" "region" {
 			for key, expected := range map[string]string{
 				"name":     "Region",
 				"type":     "string",
-				"required": "true",
+				"optional": "false",
 			} {
 				require.Equal(t, expected, state.Primary.Attributes[key])
 			}
 		},
 	}, {
-		Name: "RequiredParameterDefaultNull",
+		Name: "OptionalParameterDefaultNull",
 		Config: `
 data "coder_parameter" "region" {
 	name = "Region"
@@ -294,13 +294,13 @@ data "coder_parameter" "region" {
 			for key, expected := range map[string]string{
 				"name":     "Region",
 				"type":     "string",
-				"required": "true",
+				"optional": "false",
 			} {
 				require.Equal(t, expected, state.Primary.Attributes[key])
 			}
 		},
 	}, {
-		Name: "RequiredParameterDefaultEmpty",
+		Name: "OptionalParameterDefaultEmpty",
 		Config: `
 data "coder_parameter" "region" {
 	name = "Region"
@@ -311,7 +311,7 @@ data "coder_parameter" "region" {
 			for key, expected := range map[string]string{
 				"name":     "Region",
 				"type":     "string",
-				"required": "false",
+				"optional": "true",
 			} {
 				require.Equal(t, expected, state.Primary.Attributes[key])
 			}

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -283,7 +283,7 @@ data "coder_parameter" "region" {
 			}
 		},
 	}, {
-		Name: "OptionalParameterDefaultNull",
+		Name: "RequiredParameterDefaultNull",
 		Config: `
 data "coder_parameter" "region" {
 	name = "Region"
@@ -317,13 +317,22 @@ data "coder_parameter" "region" {
 			}
 		},
 	}, {
-		Name: "RequiredParameterDefaultEmpty",
+		Name: "OptionalParameterDefaultNotEmpty",
 		Config: `
 data "coder_parameter" "region" {
 	name = "Region"
 	type = "string"
 	default = "us-east-1"
 }`,
+		Check: func(state *terraform.ResourceState) {
+			for key, expected := range map[string]string{
+				"name":     "Region",
+				"type":     "string",
+				"optional": "true",
+			} {
+				require.Equal(t, expected, state.Primary.Attributes[key])
+			}
+		},
 	}} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -266,6 +266,64 @@ data "coder_parameter" "region" {
 }
 `,
 		ExpectError: regexp.MustCompile("cannot have the same value"),
+	}, {
+		Name: "RequiredParameterNoDefault",
+		Config: `
+data "coder_parameter" "region" {
+	name = "Region"
+	type = "string"
+}`,
+		Check: func(state *terraform.ResourceState) {
+			for key, expected := range map[string]string{
+				"name":     "Region",
+				"type":     "string",
+				"required": "true",
+			} {
+				require.Equal(t, expected, state.Primary.Attributes[key])
+			}
+		},
+	}, {
+		Name: "RequiredParameterDefaultNull",
+		Config: `
+data "coder_parameter" "region" {
+	name = "Region"
+	type = "string"
+	default = null
+}`,
+		Check: func(state *terraform.ResourceState) {
+			for key, expected := range map[string]string{
+				"name":     "Region",
+				"type":     "string",
+				"required": "true",
+			} {
+				require.Equal(t, expected, state.Primary.Attributes[key])
+			}
+		},
+	}, {
+		Name: "RequiredParameterDefaultEmpty",
+		Config: `
+data "coder_parameter" "region" {
+	name = "Region"
+	type = "string"
+	default = ""
+}`,
+		Check: func(state *terraform.ResourceState) {
+			for key, expected := range map[string]string{
+				"name":     "Region",
+				"type":     "string",
+				"required": "false",
+			} {
+				require.Equal(t, expected, state.Primary.Attributes[key])
+			}
+		},
+	}, {
+		Name: "RequiredParameterDefaultEmpty",
+		Config: `
+data "coder_parameter" "region" {
+	name = "Region"
+	type = "string"
+	default = "us-east-1"
+}`,
 	}} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6100

This PR adds a new computed property to `coder_parameter`, `optional`.

Analogically to [Terraform variables](https://servian.dev/terraform-optional-variables-and-attributes-using-null-and-optional-flag-62c5cd88f9ca) - a parameter is considered to be required if it doesn't have a `default` property, or it's `= null`. An empty string is an acceptable value, and it means that the parameter is not required. 