### PR TITLE
feat: support list(string) as coder_parameter

### DIFF
--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -28,7 +28,7 @@ Use this data source to configure editable options for workspaces.
 - `legacy_variable_name` (String) Name of the legacy Terraform variable. Coder will use it to lookup the variable value.
 - `mutable` (Boolean) Whether this value can be changed after workspace creation. This can be destructive for values like region, so use with caution!
 - `option` (Block List, Max: 64) Each "option" block defines a value for a user to select from. (see [below for nested schema](#nestedblock--option))
-- `type` (String) The type of this parameter. Must be one of: "number", "string", or "bool".
+- `type` (String) The type of this parameter. Must be one of: "number", "string", "bool", or "list(string)".
 - `validation` (Block List, Max: 1) Validate the input of a parameter. (see [below for nested schema](#nestedblock--validation))
 
 ### Read-Only

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -75,3 +75,9 @@ data "coder_parameter" "fairy_tale" {
   name = "Fairy Tale"
   type = "string"
 }
+
+data "coder_parameter" "users" {
+  name = "System users"
+  type = "list(string)"
+  default = ["root", "user1", "user2"]
+}

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -79,5 +79,5 @@ data "coder_parameter" "fairy_tale" {
 data "coder_parameter" "users" {
   name    = "System users"
   type    = "list(string)"
-  default = ["root", "user1", "user2"]
+  default = jsonencode(["root", "user1", "user2"])
 }

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -77,7 +77,7 @@ data "coder_parameter" "fairy_tale" {
 }
 
 data "coder_parameter" "users" {
-  name = "System users"
-  type = "list(string)"
+  name    = "System users"
+  type    = "list(string)"
   default = ["root", "user1", "user2"]
 }

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -180,8 +181,8 @@ func parameterDataSource() *schema.Resource {
 				Type:         schema.TypeString,
 				Default:      "string",
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"number", "string", "bool"}, false),
-				Description:  `The type of this parameter. Must be one of: "number", "string", or "bool".`,
+				ValidateFunc: validation.StringInSlice([]string{"number", "string", "bool", "list(string)"}, false),
+				Description:  `The type of this parameter. Must be one of: "number", "string", "bool", or "list(string)".`,
 			},
 			"mutable": {
 				Type:        schema.TypeBool,
@@ -327,6 +328,12 @@ func valueIsType(typ, value string) diag.Diagnostics {
 		_, err := strconv.ParseBool(value)
 		if err != nil {
 			return diag.Errorf("%q is not a bool", value)
+		}
+	case "list(string)":
+		var items []string
+		err := json.Unmarshal([]byte(value), &items)
+		if err != nil {
+			return diag.Errorf("%q is not an array of strings", value)
 		}
 	case "string":
 		// Anything is a string!


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6582

This PR adds another supported type to `coder_parameter`, a list of strings.