### PR TITLE
feat: Add ssh max timeout to coder_agent resource

### DIFF
--- a/provider/agent_test.go
+++ b/provider/agent_test.go
@@ -37,6 +37,7 @@ func TestAgent(t *testing.T) {
 					shutdown_script = "echo bye bye"
 					shutdown_script_timeout = 120
 					login_before_ready = false
+					ssh_max_timeout = "1m"
 				}
 				`,
 			Check: func(state *terraform.State) error {


### PR DESCRIPTION
## Context
[PR #6596](https://github.com/coder/coder/pull/6596) adds an option to set a max timeout for SSH connections on the coder agent. 

## Changes
Adding an option to the coder_agent resource to pass the ssh_max_timeout config to the agent init script