### PR TITLE
feat: add validation for list(string)

### DIFF
--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -390,6 +390,12 @@ func (v *Validation) Valid(typ, value string) error {
 		if v.Monotonic != "" && v.Monotonic != ValidationMonotonicIncreasing && v.Monotonic != ValidationMonotonicDecreasing {
 			return fmt.Errorf("number monotonicity can be either %q or %q", ValidationMonotonicIncreasing, ValidationMonotonicDecreasing)
 		}
+	case "list(string)":
+		var listOfStrings []string
+		err := json.Unmarshal([]byte(value), &listOfStrings)
+		if err != nil {
+			return fmt.Errorf("value %q is not valid list of strings", value)
+		}
 	}
 	return nil
 }

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -515,16 +515,16 @@ func TestValueValidatesType(t *testing.T) {
 		Max:       2,
 		Monotonic: "decreasing",
 	}, {
-		Name:  "ValidListOfString",
+		Name:  "ValidListOfStrings",
 		Type:  "list(string)",
 		Value: `["first","second","third"]`,
 	}, {
-		Name:  "InvalidListOfString",
+		Name:  "InvalidListOfStrings",
 		Type:  "list(string)",
 		Value: `["first","second","third"`,
 		Error: regexp.MustCompile("is not valid list of strings"),
 	}, {
-		Name:  "EmptyListOfString",
+		Name:  "EmptyListOfStrings",
 		Type:  "list(string)",
 		Value: `[]`,
 	}} {

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -514,6 +514,19 @@ func TestValueValidatesType(t *testing.T) {
 		Min:       0,
 		Max:       2,
 		Monotonic: "decreasing",
+	}, {
+		Name:  "ValidListOfString",
+		Type:  "list(string)",
+		Value: `["first","second","third"]`,
+	}, {
+		Name:  "InvalidListOfString",
+		Type:  "list(string)",
+		Value: `["first","second","third"`,
+		Error: regexp.MustCompile("is not valid list of strings"),
+	}, {
+		Name:  "EmptyListOfString",
+		Type:  "list(string)",
+		Value: `[]`,
 	}} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
@@ -529,6 +542,8 @@ func TestValueValidatesType(t *testing.T) {
 			if tc.Error != nil {
 				require.Error(t, err)
 				require.True(t, tc.Error.MatchString(err.Error()), "got: %s", err.Error())
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6582

This PR adds validation for a list of strings. I forgot to enable it in the previous PR.