### PR TITLE
fix: annotate multi-words fields

### DIFF
--- a/provider/decode_test.go
+++ b/provider/decode_test.go
@@ -1,0 +1,28 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/coder/terraform-provider-coder/provider"
+	"github.com/mitchellh/mapstructure"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecode(t *testing.T) {
+	const (
+		legacyVariable     = "Legacy Variable"
+		legacyVariableName = "Legacy Variable Name"
+	)
+
+	aMap := map[string]interface{}{
+		"name":                 "Parameter Name",
+		"legacy_variable":      legacyVariable,
+		"legacy_variable_name": legacyVariableName,
+	}
+
+	var param provider.Parameter
+	err := mapstructure.Decode(aMap, &param)
+	require.NoError(t, err)
+	require.Equal(t, legacyVariable, param.LegacyVariable)
+	require.Equal(t, legacyVariableName, param.LegacyVariableName)
+}

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -51,8 +51,8 @@ type Parameter struct {
 	Validation  []Validation
 	Optional    bool
 
-	LegacyVariableName string
-	LegacyVariable     string
+	LegacyVariableName string `mapstructure:"legacy_variable_name"`
+	LegacyVariable     string `mapstructure:"legacy_variable"`
 }
 
 func parameterDataSource() *schema.Resource {


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6734

This PR fixes the default `mapstructure` field annotation, which is different compared to Terraform resource attributes.