### PR TITLE
fix: add mapstructure annotation to display_name

### DIFF
--- a/provider/decode_test.go
+++ b/provider/decode_test.go
@@ -12,10 +12,13 @@ func TestDecode(t *testing.T) {
 	const (
 		legacyVariable     = "Legacy Variable"
 		legacyVariableName = "Legacy Variable Name"
+
+		displayName = "Display Name"
 	)
 
 	aMap := map[string]interface{}{
 		"name":                 "Parameter Name",
+		"display_name":         displayName,
 		"legacy_variable":      legacyVariable,
 		"legacy_variable_name": legacyVariableName,
 	}
@@ -23,6 +26,7 @@ func TestDecode(t *testing.T) {
 	var param provider.Parameter
 	err := mapstructure.Decode(aMap, &param)
 	require.NoError(t, err)
+	require.Equal(t, displayName, param.DisplayName)
 	require.Equal(t, legacyVariable, param.LegacyVariable)
 	require.Equal(t, legacyVariableName, param.LegacyVariableName)
 }

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -42,7 +42,7 @@ const (
 type Parameter struct {
 	Value       string
 	Name        string
-	DisplayName string
+	DisplayName string `mapstructure:"display_name"`
 	Description string
 	Type        string
 	Mutable     bool


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/coder/terraform-provider-coder/pull/118.

`display_name` field requires `mapstructure` annotation due to underscores.