### PR TITLE
fix: show correct min and max values in validation errors

### DIFF
--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -438,10 +438,10 @@ func (v *Validation) Valid(typ, value string) error {
 			return fmt.Errorf("value %q is not a number", value)
 		}
 		if v.Min != nil && num < *v.Min {
-			return fmt.Errorf("value %d is less than the minimum %d", num, v.Min)
+			return fmt.Errorf("value %d is less than the minimum %d", num, *v.Min)
 		}
 		if v.Max != nil && num > *v.Max {
-			return fmt.Errorf("value %d is more than the maximum %d", num, v.Max)
+			return fmt.Errorf("value %d is more than the maximum %d", num, *v.Max)
 		}
 		if v.Monotonic != "" && v.Monotonic != ValidationMonotonicIncreasing && v.Monotonic != ValidationMonotonicDecreasing {
 			return fmt.Errorf("number monotonicity can be either %q or %q", ValidationMonotonicIncreasing, ValidationMonotonicDecreasing)

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -499,13 +499,13 @@ func TestValueValidatesType(t *testing.T) {
 		Type:  "number",
 		Value: "0",
 		Min:   ptrNumber(1),
-		Error: regexp.MustCompile("is less than the minimum"),
+		Error: regexp.MustCompile("is less than the minimum 1"),
 	}, {
 		Name:  "NumberAboveMax",
 		Type:  "number",
 		Value: "2",
 		Max:   ptrNumber(1),
-		Error: regexp.MustCompile("is more than the maximum"),
+		Error: regexp.MustCompile("is more than the maximum 1"),
 	}, {
 		Name:  "InvalidBool",
 		Type:  "bool",


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/7582

This PR fixes the invalid validation error message, show ptr instead of the value. 