### PR TITLE
feat: add order to coder_parameter

### DIFF
--- a/docs/data-sources/git_auth.md
+++ b/docs/data-sources/git_auth.md
@@ -46,5 +46,3 @@ EOF
 ### Read-Only
 
 - `access_token` (String) The access token returned by the git authentication provider. This can be used to pre-authenticate command-line tools.
-
-

--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -29,7 +29,7 @@ Use this data source to configure editable options for workspaces.
 - `legacy_variable_name` (String, Deprecated) Name of the legacy Terraform variable. Coder will use it to lookup the variable value.
 - `mutable` (Boolean) Whether this value can be changed after workspace creation. This can be destructive for values like region, so use with caution!
 - `option` (Block List, Max: 64) Each "option" block defines a value for a user to select from. (see [below for nested schema](#nestedblock--option))
-- `priority` (Number) The priority of a template parameter determines its position in the UI/CLI presentation. A higher priority parameter is positioned ahead of a lower priority one and parameters with the same priority are ordered by name in ascending order.
+- `order` (Number) The order determines the position of a template parameter in the UI/CLI presentation. A parameter with lower order is positioned ahead of a high order one and parameters with the same order are sorted by name in ascending order.
 - `type` (String) The type of this parameter. Must be one of: "number", "string", "bool", or "list(string)".
 - `validation` (Block List, Max: 1) Validate the input of a parameter. (see [below for nested schema](#nestedblock--validation))
 

--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -29,7 +29,7 @@ Use this data source to configure editable options for workspaces.
 - `legacy_variable_name` (String, Deprecated) Name of the legacy Terraform variable. Coder will use it to lookup the variable value.
 - `mutable` (Boolean) Whether this value can be changed after workspace creation. This can be destructive for values like region, so use with caution!
 - `option` (Block List, Max: 64) Each "option" block defines a value for a user to select from. (see [below for nested schema](#nestedblock--option))
-- `priority` (Number) The priority of template parameters determines their position ahead of parameters with lower priorities in the UI/CLI presentation.
+- `priority` (Number) The priority of a template parameter determines its position in the UI/CLI presentation. A higher priority parameter is positioned ahead of a lower priority one and parameters with the same priority are ordered by name in ascending order.
 - `type` (String) The type of this parameter. Must be one of: "number", "string", "bool", or "list(string)".
 - `validation` (Block List, Max: 1) Validate the input of a parameter. (see [below for nested schema](#nestedblock--validation))
 

--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -29,7 +29,7 @@ Use this data source to configure editable options for workspaces.
 - `legacy_variable_name` (String, Deprecated) Name of the legacy Terraform variable. Coder will use it to lookup the variable value.
 - `mutable` (Boolean) Whether this value can be changed after workspace creation. This can be destructive for values like region, so use with caution!
 - `option` (Block List, Max: 64) Each "option" block defines a value for a user to select from. (see [below for nested schema](#nestedblock--option))
-- `order` (Number) The order determines the position of a template parameter in the UI/CLI presentation. A parameter with lower order is positioned ahead of a high order one and parameters with the same order are sorted by name in ascending order.
+- `order` (Number) The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order).
 - `type` (String) The type of this parameter. Must be one of: "number", "string", "bool", or "list(string)".
 - `validation` (Block List, Max: 1) Validate the input of a parameter. (see [below for nested schema](#nestedblock--validation))
 

--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -29,6 +29,7 @@ Use this data source to configure editable options for workspaces.
 - `legacy_variable_name` (String, Deprecated) Name of the legacy Terraform variable. Coder will use it to lookup the variable value.
 - `mutable` (Boolean) Whether this value can be changed after workspace creation. This can be destructive for values like region, so use with caution!
 - `option` (Block List, Max: 64) Each "option" block defines a value for a user to select from. (see [below for nested schema](#nestedblock--option))
+- `priority` (Number) The priority of template parameters determines their position ahead of parameters with lower priorities in the UI/CLI presentation.
 - `type` (String) The type of this parameter. Must be one of: "number", "string", "bool", or "list(string)".
 - `validation` (Block List, Max: 1) Validate the input of a parameter. (see [below for nested schema](#nestedblock--validation))
 
@@ -67,5 +68,3 @@ Read-Only:
 
 - `max_disabled` (Boolean) Helper field to check if max is present
 - `min_disabled` (Boolean) Helper field to check if min is present
-
-

--- a/docs/data-sources/provisioner.md
+++ b/docs/data-sources/provisioner.md
@@ -20,5 +20,3 @@ Use this data source to get information about the Coder provisioner.
 - `arch` (String) The architecture of the host. This exposes `runtime.GOARCH` (see https://pkg.go.dev/runtime#pkg-constants).
 - `id` (String) The ID of this resource.
 - `os` (String) The operating system of the host. This exposes `runtime.GOOS` (see https://pkg.go.dev/runtime#pkg-constants).
-
-

--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -37,5 +37,3 @@ resource "kubernetes_pod" "dev" {
 - `owner_session_token` (String) Session token for interfacing with a Coder deployment. It is regenerated everytime a workspace is started.
 - `start_count` (Number) A computed count based on "transition" state. If "start", count will equal 1.
 - `transition` (String) Either "start" or "stop". Use this to start/stop resources with "count".
-
-

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -79,5 +79,3 @@ Optional:
 
 - `display_name` (String) The user-facing name of this value.
 - `timeout` (Number) The maximum time the command is allowed to run in seconds.
-
-

--- a/docs/resources/agent_instance.md
+++ b/docs/resources/agent_instance.md
@@ -40,5 +40,3 @@ resource "coder_agent_instance" "dev" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -90,5 +90,3 @@ Required:
 - `interval` (Number) Duration in seconds to wait between healthcheck requests.
 - `threshold` (Number) Number of consecutive heathcheck failures before returning an unhealthy status.
 - `url` (String) HTTP address used determine the application readiness. A successful health check is a HTTP response code less than 500 returned before healthcheck.interval seconds.
-
-

--- a/docs/resources/metadata.md
+++ b/docs/resources/metadata.md
@@ -80,5 +80,3 @@ Optional:
 Read-Only:
 
 - `is_null` (Boolean)
-
-

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -41,16 +41,18 @@ data "coder_parameter" "is_public_instance" {
 }
 
 data "coder_parameter" "cores" {
-  name    = "CPU Cores"
-  type    = "number"
-  icon    = "/icon/cpu.svg"
-  default = 3
+  name     = "CPU Cores"
+  type     = "number"
+  icon     = "/icon/cpu.svg"
+  default  = 3
+  priority = 10
 }
 
 data "coder_parameter" "disk_size" {
-  name    = "Disk Size"
-  type    = "number"
-  default = "5"
+  name     = "Disk Size"
+  type     = "number"
+  default  = "5"
+  priority = 8
   validation {
     # This can apply to number.
     min       = 0

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -41,18 +41,18 @@ data "coder_parameter" "is_public_instance" {
 }
 
 data "coder_parameter" "cores" {
-  name     = "CPU Cores"
-  type     = "number"
-  icon     = "/icon/cpu.svg"
-  default  = 3
-  priority = 10
+  name    = "CPU Cores"
+  type    = "number"
+  icon    = "/icon/cpu.svg"
+  default = 3
+  order   = 10
 }
 
 data "coder_parameter" "disk_size" {
-  name     = "Disk Size"
-  type     = "number"
-  default  = "5"
-  priority = 8
+  name    = "Disk Size"
+  type    = "number"
+  default = "5"
+  order   = 8
   validation {
     # This can apply to number.
     min       = 0

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -57,6 +57,8 @@ type Parameter struct {
 	Validation  []Validation
 	Optional    bool
 
+	Priority int
+
 	LegacyVariableName string `mapstructure:"legacy_variable_name"`
 	LegacyVariable     string `mapstructure:"legacy_variable"`
 }
@@ -90,6 +92,7 @@ func parameterDataSource() *schema.Resource {
 				Option      interface{}
 				Validation  interface{}
 				Optional    interface{}
+				Priority    interface{}
 
 				LegacyVariableName interface{}
 				LegacyVariable     interface{}
@@ -122,6 +125,7 @@ func parameterDataSource() *schema.Resource {
 					rd.Set("optional", val)
 					return val
 				}(),
+				Priority:           rd.Get("priority"),
 				LegacyVariableName: rd.Get("legacy_variable_name"),
 				LegacyVariable:     rd.Get("legacy_variable"),
 			}, &parameter)
@@ -330,6 +334,11 @@ func parameterDataSource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether this value is optional.",
+			},
+			"priority": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The priority of template parameters determines their position ahead of parameters with lower priorities in the UI/CLI presentation.",
 			},
 			"legacy_variable_name": {
 				Type:         schema.TypeString,

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -338,7 +338,7 @@ func parameterDataSource() *schema.Resource {
 			"priority": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The priority of template parameters determines their position ahead of parameters with lower priorities in the UI/CLI presentation.",
+				Description: "The priority of a template parameter determines its position in the UI/CLI presentation. A higher priority parameter is positioned ahead of a lower priority one and parameters with the same priority are ordered by name in ascending order.",
 			},
 			"legacy_variable_name": {
 				Type:         schema.TypeString,

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -57,7 +57,7 @@ type Parameter struct {
 	Validation  []Validation
 	Optional    bool
 
-	Priority int
+	Order int
 
 	LegacyVariableName string `mapstructure:"legacy_variable_name"`
 	LegacyVariable     string `mapstructure:"legacy_variable"`
@@ -92,7 +92,7 @@ func parameterDataSource() *schema.Resource {
 				Option      interface{}
 				Validation  interface{}
 				Optional    interface{}
-				Priority    interface{}
+				Order       interface{}
 
 				LegacyVariableName interface{}
 				LegacyVariable     interface{}
@@ -125,7 +125,7 @@ func parameterDataSource() *schema.Resource {
 					rd.Set("optional", val)
 					return val
 				}(),
-				Priority:           rd.Get("priority"),
+				Order:              rd.Get("order"),
 				LegacyVariableName: rd.Get("legacy_variable_name"),
 				LegacyVariable:     rd.Get("legacy_variable"),
 			}, &parameter)
@@ -335,10 +335,10 @@ func parameterDataSource() *schema.Resource {
 				Computed:    true,
 				Description: "Whether this value is optional.",
 			},
-			"priority": {
+			"order": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The priority of a template parameter determines its position in the UI/CLI presentation. A higher priority parameter is positioned ahead of a lower priority one and parameters with the same priority are ordered by name in ascending order.",
+				Description: "The order determines the position of a template parameter in the UI/CLI presentation. A parameter with lower order is positioned ahead of a high order one and parameters with the same order are sorted by name in ascending order.",
 			},
 			"legacy_variable_name": {
 				Type:         schema.TypeString,

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -338,7 +338,7 @@ func parameterDataSource() *schema.Resource {
 			"order": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Description: "The order determines the position of a template parameter in the UI/CLI presentation. A parameter with lower order is positioned ahead of a high order one and parameters with the same order are sorted by name in ascending order.",
+				Description: "The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order).",
 			},
 			"legacy_variable_name": {
 				Type:         schema.TypeString,

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -43,6 +43,7 @@ func TestParameter(t *testing.T) {
 					icon = "/icon/east.svg"
 					description = "Select for east!"
 				}
+				priority = 5
 			}
 			`,
 		Check: func(state *terraform.ResourceState) {
@@ -62,6 +63,7 @@ func TestParameter(t *testing.T) {
 				"option.1.value":       "us-east1-a",
 				"option.1.icon":        "/icon/east.svg",
 				"option.1.description": "Select for east!",
+				"priority":             "5",
 			} {
 				require.Equal(t, value, attrs[key])
 			}

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -43,7 +43,7 @@ func TestParameter(t *testing.T) {
 					icon = "/icon/east.svg"
 					description = "Select for east!"
 				}
-				priority = 5
+				order = 5
 			}
 			`,
 		Check: func(state *terraform.ResourceState) {
@@ -63,7 +63,7 @@ func TestParameter(t *testing.T) {
 				"option.1.value":       "us-east1-a",
 				"option.1.icon":        "/icon/east.svg",
 				"option.1.description": "Select for east!",
-				"priority":             "5",
+				"order":                "5",
 			} {
 				require.Equal(t, value, attrs[key])
 			}


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/8193

This PR adds `order` property to `coder_parameter` to determine the position of parameters presented in the UI/CLI form. More details can be found in the related issue.