### PR TITLE
feat: ephemeral parameters must be optional

### DIFF
--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -75,6 +75,7 @@ data "coder_parameter" "fairy_tale" {
   name      = "Fairy Tale"
   type      = "string"
   mutable   = true
+  default   = "Hansel and Gretel"
   ephemeral = true
 }
 

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -134,6 +134,10 @@ func parameterDataSource() *schema.Resource {
 				return diag.Errorf("parameter can't be immutable and ephemeral")
 			}
 
+			if !parameter.Optional && parameter.Ephemeral {
+				return diag.Errorf("ephemeral parameter requires the default property")
+			}
+
 			if len(parameter.Validation) == 1 {
 				validation := &parameter.Validation[0]
 				err = validation.Valid(parameter.Type, value)

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -31,6 +31,7 @@ func TestParameter(t *testing.T) {
 					EOT
 				mutable = true
 				icon = "/icon/region.svg"
+				default = "us-east1-a"
 				option {
 					name = "US Central"
 					value = "us-central1-a"
@@ -65,6 +66,7 @@ func TestParameter(t *testing.T) {
 				"option.1.icon":        "/icon/east.svg",
 				"option.1.description": "Select for east!",
 				"order":                "5",
+				"default":              "us-east1-a",
 				"ephemeral":            "true",
 			} {
 				require.Equal(t, value, attrs[key])
@@ -558,11 +560,23 @@ data "coder_parameter" "region" {
 			data "coder_parameter" "region" {
 				name = "Region"
 				type = "string"
+				default = "abc"
 				mutable = false
 				ephemeral = true
 			}
 			`,
 		ExpectError: regexp.MustCompile("parameter can't be immutable and ephemeral"),
+	}, {
+		Name: "RequiredEphemeralError",
+		Config: `
+			data "coder_parameter" "region" {
+				name = "Region"
+				type = "string"
+				mutable = true
+				ephemeral = true
+			}
+			`,
+		ExpectError: regexp.MustCompile("ephemeral parameter requires the default property"),
 	}} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/6828

This PR introduces another constraint for ephemeral parameters:
* ephemeral parameters can't be marked as required, so they must have the `default` property defined.