### PR TITLE
chore: bump go to 1.20 in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.17
+          go-version: 1.20
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: 1.20.6
 
       - name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
I believe it was mistakenly left out. 