### PR TITLE
fix: validate that `coder_script` has a way to run

### DIFF
--- a/provider/script.go
+++ b/provider/script.go
@@ -18,6 +18,13 @@ func scriptResource() *schema.Resource {
 		Description: "Use this resource to run a script from an agent.",
 		CreateContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics {
 			rd.SetId(uuid.NewString())
+			runOnStart, _ := rd.Get("run_on_start").(bool)
+			runOnStop, _ := rd.Get("run_on_stop").(bool)
+			cron, _ := rd.Get("cron").(string)
+
+			if !runOnStart && !runOnStop && cron == "" {
+				return diag.Errorf("at least one of run_on_start, run_on_stop, or cron must be set")
+			}
 			return nil
 		},
 		ReadContext:   schema.NoopContext,

--- a/provider/script_test.go
+++ b/provider/script_test.go
@@ -1,0 +1,75 @@
+package provider_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/coder/terraform-provider-coder/provider"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestScript(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]*schema.Provider{
+			"coder": provider.New(),
+		},
+		IsUnitTest: true,
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "coder" {
+			}
+			resource "coder_script" "example" {
+				agent_id = "some id"
+				display_name = "Hey"
+				script = "Wow"
+				cron = "* * * * *"
+			}
+			`,
+			Check: func(state *terraform.State) error {
+				require.Len(t, state.Modules, 1)
+				require.Len(t, state.Modules[0].Resources, 1)
+				script := state.Modules[0].Resources["coder_script.example"]
+				require.NotNil(t, script)
+				t.Logf("script attributes: %#v", script.Primary.Attributes)
+				for key, expected := range map[string]string{
+					"agent_id":     "some id",
+					"display_name": "Hey",
+					"script":       "Wow",
+					"cron":         "* * * * *",
+				} {
+					require.Equal(t, expected, script.Primary.Attributes[key])
+				}
+				return nil
+			},
+		}},
+	})
+}
+
+func TestScriptNeverRuns(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]*schema.Provider{
+			"coder": provider.New(),
+		},
+		IsUnitTest: true,
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "coder" {
+			}
+			resource "coder_script" "example" {
+				agent_id = ""
+				display_name = "Hey"
+				script = "Wow"
+			}
+			`,
+			ExpectError: regexp.MustCompile(`at least one of run_on_start, run_on_stop, or cron must be set`),
+		}},
+	})
+}


### PR DESCRIPTION
Previously, this would just silently push the script and it would never run, because it wasn't configured to do so.

This changes it so all scripts have to be ran at some point.