### PR TITLE
feat: add `order` property to agent_metadata

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -97,4 +97,5 @@ Required:
 Optional:
 
 - `display_name` (String) The user-facing name of this value.
+- `order` (Number) The order determines the position of agent metadata in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by key (ascending order).
 - `timeout` (Number) The maximum time the command is allowed to run in seconds.

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -26,6 +26,23 @@ resource "coder_agent" "dev" {
     web_terminal    = true
     ssh_helper      = false
   }
+
+  metadata {
+    display_name = "CPU Usage"
+    key          = "cpu_usage"
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+    order        = 2
+  }
+  metadata {
+    display_name = "RAM Usage"
+    key          = "ram_usage"
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+    order        = 1
+  }
 }
 
 resource "kubernetes_pod" "dev" {

--- a/examples/resources/coder_agent/resource.tf
+++ b/examples/resources/coder_agent/resource.tf
@@ -11,6 +11,23 @@ resource "coder_agent" "dev" {
     web_terminal    = true
     ssh_helper      = false
   }
+
+  metadata {
+    display_name = "CPU Usage"
+    key          = "cpu_usage"
+    script       = "coder stat cpu"
+    interval     = 10
+    timeout      = 1
+    order        = 2
+  }
+  metadata {
+    display_name = "RAM Usage"
+    key          = "ram_usage"
+    script       = "coder stat mem"
+    interval     = 10
+    timeout      = 1
+    order        = 1
+  }
 }
 
 resource "kubernetes_pod" "dev" {

--- a/provider/agent.go
+++ b/provider/agent.go
@@ -239,6 +239,11 @@ func agentResource() *schema.Resource {
 							ForceNew:    true,
 							Required:    true,
 						},
+						"order": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "The order determines the position of agent metadata in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by key (ascending order).",
+						},
 					},
 				},
 			},

--- a/provider/agent_test.go
+++ b/provider/agent_test.go
@@ -39,7 +39,6 @@ func TestAgent(t *testing.T) {
 					motd_file = "/etc/motd"
 					shutdown_script = "echo bye bye"
 					shutdown_script_timeout = 120
-					order = 7
 				}
 				`,
 			Check: func(state *terraform.State) error {
@@ -61,7 +60,6 @@ func TestAgent(t *testing.T) {
 					"motd_file",
 					"shutdown_script",
 					"shutdown_script_timeout",
-					"order",
 				} {
 					value := resource.Primary.Attributes[key]
 					t.Logf("%q = %q", key, value)
@@ -227,6 +225,7 @@ func TestAgent_Metadata(t *testing.T) {
 						script = "ps aux | wc -l"
 						interval = 5
 						timeout = 1
+						order = 7
 					}
 				}
 				`,
@@ -246,6 +245,7 @@ func TestAgent_Metadata(t *testing.T) {
 				require.Equal(t, "ps aux | wc -l", attr["metadata.0.script"])
 				require.Equal(t, "5", attr["metadata.0.interval"])
 				require.Equal(t, "1", attr["metadata.0.timeout"])
+				require.Equal(t, "7", attr["metadata.0.order"])
 				return nil
 			},
 		}},

--- a/provider/agent_test.go
+++ b/provider/agent_test.go
@@ -39,6 +39,7 @@ func TestAgent(t *testing.T) {
 					motd_file = "/etc/motd"
 					shutdown_script = "echo bye bye"
 					shutdown_script_timeout = 120
+					order = 7
 				}
 				`,
 			Check: func(state *terraform.State) error {
@@ -60,6 +61,7 @@ func TestAgent(t *testing.T) {
 					"motd_file",
 					"shutdown_script",
 					"shutdown_script_timeout",
+					"order",
 				} {
 					value := resource.Primary.Attributes[key]
 					t.Logf("%q = %q", key, value)


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/8487

This PR adds `order` property to `coder_metadata`.