### PR TITLE
docs: deprecate startup_script_timeout & shutdown_script_timeout

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -78,10 +78,10 @@ resource "kubernetes_pod" "dev" {
 - `metadata` (Block List) Each "metadata" block defines a single item consisting of a key/value pair. This feature is in alpha and may break in future releases. (see [below for nested schema](#nestedblock--metadata))
 - `motd_file` (String) The path to a file within the workspace containing a message to display to users when they login via SSH. A typical value would be /etc/motd.
 - `shutdown_script` (String) A script to run before the agent is stopped. The script should exit when it is done to signal that the workspace can be stopped.
-- `shutdown_script_timeout` (Number, Deprecated) Time in seconds until the agent lifecycle status is marked as timed out during shutdown, this happens when the shutdown script has not completed (exited) in the given time.
+- `shutdown_script_timeout` (Number) Time in seconds until the agent lifecycle status is marked as timed out during shutdown, this happens when the shutdown script has not completed (exited) in the given time.
 - `startup_script` (String) A script to run after the agent starts. The script should exit when it is done to signal that the agent is ready.
 - `startup_script_behavior` (String) This option sets the behavior of the `startup_script`. When set to "blocking", the startup_script must exit before the workspace is ready. When set to "non-blocking", the startup_script may run in the background and the workspace will be ready immediately. Default is "non-blocking", although "blocking" is recommended.
-- `startup_script_timeout` (Number, Deprecated) Time in seconds until the agent lifecycle status is marked as timed out during start, this happens when the startup script has not completed (exited) in the given time.
+- `startup_script_timeout` (Number) Time in seconds until the agent lifecycle status is marked as timed out during start, this happens when the startup script has not completed (exited) in the given time.
 - `troubleshooting_url` (String) A URL to a document with instructions for troubleshooting problems with the agent.
 
 ### Read-Only

--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -78,10 +78,10 @@ resource "kubernetes_pod" "dev" {
 - `metadata` (Block List) Each "metadata" block defines a single item consisting of a key/value pair. This feature is in alpha and may break in future releases. (see [below for nested schema](#nestedblock--metadata))
 - `motd_file` (String) The path to a file within the workspace containing a message to display to users when they login via SSH. A typical value would be /etc/motd.
 - `shutdown_script` (String) A script to run before the agent is stopped. The script should exit when it is done to signal that the workspace can be stopped.
-- `shutdown_script_timeout` (Number) Time in seconds until the agent lifecycle status is marked as timed out during shutdown, this happens when the shutdown script has not completed (exited) in the given time.
+- `shutdown_script_timeout` (Number, Deprecated) Time in seconds until the agent lifecycle status is marked as timed out during shutdown, this happens when the shutdown script has not completed (exited) in the given time.
 - `startup_script` (String) A script to run after the agent starts. The script should exit when it is done to signal that the agent is ready.
 - `startup_script_behavior` (String) This option sets the behavior of the `startup_script`. When set to "blocking", the startup_script must exit before the workspace is ready. When set to "non-blocking", the startup_script may run in the background and the workspace will be ready immediately. Default is "non-blocking", although "blocking" is recommended.
-- `startup_script_timeout` (Number) Time in seconds until the agent lifecycle status is marked as timed out during start, this happens when the startup script has not completed (exited) in the given time.
+- `startup_script_timeout` (Number, Deprecated) Time in seconds until the agent lifecycle status is marked as timed out during start, this happens when the startup script has not completed (exited) in the given time.
 - `troubleshooting_url` (String) A URL to a document with instructions for troubleshooting problems with the agent.
 
 ### Read-Only

--- a/provider/agent.go
+++ b/provider/agent.go
@@ -131,6 +131,7 @@ func agentResource() *schema.Resource {
 				ForceNew:     true,
 				Optional:     true,
 				Description:  "Time in seconds until the agent lifecycle status is marked as timed out during start, this happens when the startup script has not completed (exited) in the given time.",
+				Deprecated:   "This feature is deprecated and has no effect. This attribute will be removed in a future version of the provider.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"shutdown_script": {
@@ -145,6 +146,7 @@ func agentResource() *schema.Resource {
 				ForceNew:     true,
 				Optional:     true,
 				Description:  "Time in seconds until the agent lifecycle status is marked as timed out during shutdown, this happens when the shutdown script has not completed (exited) in the given time.",
+				Deprecated:   "This feature is deprecated and has no effect. This attribute will be removed in a future version of the provider.",
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"token": {


### PR DESCRIPTION
this PR deprecates the `startup_script_timeout` & `shutdown_script_timeout` agent arguments in our provider documentation.