### PR TITLE
fix: metadata order with ForceNew

### DIFF
--- a/provider/agent.go
+++ b/provider/agent.go
@@ -241,8 +241,9 @@ func agentResource() *schema.Resource {
 						},
 						"order": {
 							Type:        schema.TypeInt,
-							Optional:    true,
 							Description: "The order determines the position of agent metadata in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by key (ascending order).",
+							ForceNew:    true,
+							Optional:    true,
 						},
 					},
 				},


### PR DESCRIPTION
Related: https://github.com/coder/coder/pull/12066

While manually testing the coder implementation, I couldn't update the metadata (remove `order` property). The definition is missing `ForceNew`.