### PR TITLE
fix!: add extra validation for start_blocks_login

### DIFF
--- a/provider/script.go
+++ b/provider/script.go
@@ -19,11 +19,15 @@ func scriptResource() *schema.Resource {
 		CreateContext: func(_ context.Context, rd *schema.ResourceData, _ interface{}) diag.Diagnostics {
 			rd.SetId(uuid.NewString())
 			runOnStart, _ := rd.Get("run_on_start").(bool)
+			startBlocksLogin, _ := rd.Get("start_blocks_login").(bool)
 			runOnStop, _ := rd.Get("run_on_stop").(bool)
 			cron, _ := rd.Get("cron").(string)
 
 			if !runOnStart && !runOnStop && cron == "" {
 				return diag.Errorf("at least one of run_on_start, run_on_stop, or cron must be set")
+			}
+			if !runOnStart && startBlocksLogin {
+				return diag.Errorf("start_blocks_login can only be set if run_on_start is true")
 			}
 			return nil
 		},

--- a/provider/script_test.go
+++ b/provider/script_test.go
@@ -73,3 +73,64 @@ func TestScriptNeverRuns(t *testing.T) {
 		}},
 	})
 }
+
+func TestScriptStartBlocksLoginRequiresRunOnStart(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]*schema.Provider{
+			"coder": provider.New(),
+		},
+		IsUnitTest: true,
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "coder" {
+			}
+			resource "coder_script" "example" {
+				agent_id = ""
+				display_name = "Hey"
+				script = "Wow"
+				run_on_stop = true
+				start_blocks_login = true
+			}
+			`,
+			ExpectError: regexp.MustCompile(`start_blocks_login can only be set if run_on_start is true`),
+		}},
+	})
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]*schema.Provider{
+			"coder": provider.New(),
+		},
+		IsUnitTest: true,
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "coder" {
+			}
+			resource "coder_script" "example" {
+				agent_id = ""
+				display_name = "Hey"
+				script = "Wow"
+				start_blocks_login = true
+				run_on_start = true
+			}
+			`,
+			Check: func(state *terraform.State) error {
+				require.Len(t, state.Modules, 1)
+				require.Len(t, state.Modules[0].Resources, 1)
+				script := state.Modules[0].Resources["coder_script.example"]
+				require.NotNil(t, script)
+				t.Logf("script attributes: %#v", script.Primary.Attributes)
+				for key, expected := range map[string]string{
+					"agent_id":           "",
+					"display_name":       "Hey",
+					"script":             "Wow",
+					"start_blocks_login": "true",
+					"run_on_start":       "true",
+				} {
+					require.Equal(t, expected, script.Primary.Attributes[key])
+				}
+				return nil
+			},
+		}},
+	})
+}


### PR DESCRIPTION
This was originally part of #191 but split out because it is a bit of a breaking change, but hopefully it will help users avoid confusion when one is set without the other and the feature doesn't work.

This guarantee also makes our coder/coder more correct since it's common pratice to _only_ look at `start_blocks_login`.
