### PR TITLE
feat: relax error message for number-typed coder parameters

### DIFF
--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -57,7 +57,7 @@ Optional:
 
 Optional:
 
-- `error` (String) An error message to display if the value doesn't match the provided regex.
+- `error` (String) An error message to display if the value breaks the validation rules.
 - `max` (Number) The maximum of a number parameter.
 - `min` (Number) The minimum of a number parameter.
 - `monotonic` (String) Number monotonicity, either increasing or decreasing.

--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -57,7 +57,7 @@ Optional:
 
 Optional:
 
-- `error` (String) An error message to display if the value breaks the validation rules.
+- `error` (String) An error message to display if the value breaks the validation rules. The following placeholders are supported: {max}, {min}, and {value}.
 - `max` (Number) The maximum of a number parameter.
 - `min` (Number) The minimum of a number parameter.
 - `monotonic` (String) Number monotonicity, either increasing or decreasing.

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -317,7 +317,7 @@ func parameterDataSource() *schema.Resource {
 						"error": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "An error message to display if the value breaks the validation rules.",
+							Description: "An error message to display if the value breaks the validation rules. The following placeholders are supported: {max}, {min}, and {value}.",
 						},
 					},
 				},

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -446,7 +446,7 @@ func (v *Validation) Valid(typ, value string) error {
 			return validationError(v.Error, "value %d is more than the maximum %d", num, v.Max)
 		}
 		if v.Monotonic != "" && v.Monotonic != ValidationMonotonicIncreasing && v.Monotonic != ValidationMonotonicDecreasing {
-			return validationError(v.Error, "number monotonicity can be either %q or %q", ValidationMonotonicIncreasing, ValidationMonotonicDecreasing)
+			return fmt.Errorf("number monotonicity can be either %q or %q", ValidationMonotonicIncreasing, ValidationMonotonicDecreasing)
 		}
 	case "list(string)":
 		var listOfStrings []string

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -528,6 +528,20 @@ data "coder_parameter" "region" {
 			`,
 		ExpectError: regexp.MustCompile("is more than the maximum"),
 	}, {
+		Name: "NumberValidation_CustomError",
+		Config: `
+			data "coder_parameter" "region" {
+				name = "Region"
+				type = "number"
+				default = 5
+				validation {
+					max = 3
+					error = "foobar"
+				}
+			}
+			`,
+		ExpectError: regexp.MustCompile("foobar"),
+	}, {
 		Name: "NumberValidation_NotInRange",
 		Config: `
 			data "coder_parameter" "region" {

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -150,19 +150,6 @@ func TestParameter(t *testing.T) {
 			`,
 		ExpectError: regexp.MustCompile("is not a bool"),
 	}, {
-		Name: "Bool_CustomError",
-		Config: `
-			data "coder_parameter" "region" {
-				name = "region"
-				type = "bool"
-				default = true
-				validation {
-					error = "foobar"
-				}
-			}
-			`,
-		ExpectError: regexp.MustCompile("is not a bool"),
-	}, {
 		Name: "OptionNotBool",
 		Config: `
 			data "coder_parameter" "region" {

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -150,6 +150,19 @@ func TestParameter(t *testing.T) {
 			`,
 		ExpectError: regexp.MustCompile("is not a bool"),
 	}, {
+		Name: "Bool_CustomError",
+		Config: `
+			data "coder_parameter" "region" {
+				name = "region"
+				type = "bool"
+				default = true
+				validation {
+					error = "foobar"
+				}
+			}
+			`,
+		ExpectError: regexp.MustCompile("is not a bool"),
+	}, {
 		Name: "OptionNotBool",
 		Config: `
 			data "coder_parameter" "region" {


### PR DESCRIPTION
Related: https://github.com/coder/coder/issues/12192

Right now, only string-typed parameters can use custom messages. This PR relaxes strict validation rules to support custom errors for number-typed coder parameters.