### PR TITLE
feat: allow `validation` to be used with `option`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ to setup your local Terraform to use your local version rather than the registry
    2. Run `terraform init` and observe a warning like `Warning: Provider development overrides are in effect`
 4. Run `go build -o terraform-provider-coder` to build the provider binary, which Terraform will try locate and execute
 5. All local Terraform runs will now use your local provider!
+6. _**NOTE**: we vendor in this provider into `github.com/coder/coder`, so if you're testing with a local clone then you should also run `go mod edit -replace github.com/coder/terraform-provider-coder=/path/to/terraform-provider-coder` in your clone._

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # terraform-provider-coder
 
-See [Coder](https://github.com/coder/coder).
+Terraform provider for [Coder](https://github.com/coder/coder).
+
+### Developing
+
+Follow the instructions outlined in the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers)
+to setup your local Terraform to use your local version rather than the registry version.
+
+1. Create a file named `.terraformrc` in your `$HOME` directory
+2. Add the following content:
+   ```hcl
+    provider_installation {
+        # Override the coder/coder provider to use your local version
+        dev_overrides {
+          "coder/coder" = "/path/to/terraform-provider-coder"
+        }
+
+        # For all other providers, install them directly from their origin provider
+        # registries as normal. If you omit this, Terraform will _only_ use
+        # the dev_overrides block, and so no other providers will be available.
+        direct {}
+    }
+   ```
+3. (optional, but recommended) Validate your configuration:
+    1. Create a new `main.tf` file and include:
+      ```hcl
+      terraform {
+          required_providers {
+              coder = {
+                  source = "coder/coder"
+              }
+          }
+      }
+      ```
+   2. Run `terraform init` and observe a warning like `Warning: Provider development overrides are in effect`
+4. Run `go build -o terraform-provider-coder` to build the provider binary, which Terraform will try locate and execute
+5. All local Terraform runs will now use your local provider!

--- a/examples/resources/coder_parameter/resource.tf
+++ b/examples/resources/coder_parameter/resource.tf
@@ -85,3 +85,33 @@ data "coder_parameter" "users" {
   type         = "list(string)"
   default      = jsonencode(["root", "user1", "user2"])
 }
+
+data "coder_parameter" "home_volume_size" {
+  name        = "Home Volume Size"
+  description = <<-EOF
+  How large should your home volume be?
+  EOF
+  type        = "number"
+  default     = 30
+  mutable     = true
+  order       = 3
+
+  option {
+    name  = "30GB"
+    value = 30
+  }
+
+  option {
+    name  = "60GB"
+    value = 60
+  }
+
+  option {
+    name  = "100GB"
+    value = 100
+  }
+
+  validation {
+    monotonic = "increasing"
+  }
+}

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -231,12 +231,11 @@ func parameterDataSource() *schema.Resource {
 				},
 			},
 			"option": {
-				Type:          schema.TypeList,
-				Description:   "Each \"option\" block defines a value for a user to select from.",
-				ForceNew:      true,
-				Optional:      true,
-				MaxItems:      64,
-				ConflictsWith: []string{"validation"},
+				Type:        schema.TypeList,
+				Description: "Each \"option\" block defines a value for a user to select from.",
+				ForceNew:    true,
+				Optional:    true,
+				MaxItems:    64,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -276,11 +275,10 @@ func parameterDataSource() *schema.Resource {
 				},
 			},
 			"validation": {
-				Type:          schema.TypeList,
-				MaxItems:      1,
-				Optional:      true,
-				Description:   "Validate the input of a parameter.",
-				ConflictsWith: []string{"option"},
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Description: "Validate the input of a parameter.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"min": {
@@ -409,6 +407,9 @@ func (v *Validation) Valid(typ, value string) error {
 		}
 		if !v.MaxDisabled {
 			return fmt.Errorf("a max cannot be specified for a %s type", typ)
+		}
+		if v.Monotonic != "" {
+			return fmt.Errorf("monotonic validation can only be specified for number types, not %s types", typ)
 		}
 	}
 	if typ != "string" && v.Regex != "" {

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -445,7 +445,7 @@ data "coder_parameter" "region" {
 		Config: `
 			data "coder_parameter" "region" {
 			  name        = "Region"
-              type        = "number"
+			  type        = "number"
 			  description = <<-EOF
 			  Always pick a larger region.
 			  EOF
@@ -467,7 +467,7 @@ data "coder_parameter" "region" {
 			  }
 
 			  validation {
-			    monotonic = "increasing"
+				monotonic = "increasing"
 			  }
 			}
 			`,


### PR DESCRIPTION
Addresses https://github.com/coder/coder/issues/11579, PR in coder/coder will close

Currently we have a conflict declared between `option` and `validation` configs in `coder_parameter` Terraform resources (@mtojek do you have some historical context as to why that was the case?).

This PR removes that conflict since there is nothing inherent in the codebase disallowing them, and we need to allow both to to accommodate the use-case mentioned in the linked issue.

I expanded the tests and added documentation for testing the provider locally.
