### PR TITLE
fix: set owner name and email to "default"

### DIFF
--- a/provider/workspace.go
+++ b/provider/workspace.go
@@ -35,6 +35,9 @@ func workspaceDataSource() *schema.Resource {
 			_ = rd.Set("owner", owner)
 
 			ownerEmail := os.Getenv("CODER_WORKSPACE_OWNER_EMAIL")
+			if ownerEmail == "" {
+				ownerEmail = "default"
+			}
 			_ = rd.Set("owner_email", ownerEmail)
 
 			ownerGroupsText := os.Getenv("CODER_WORKSPACE_OWNER_GROUPS")
@@ -48,6 +51,9 @@ func workspaceDataSource() *schema.Resource {
 			_ = rd.Set("owner_groups", ownerGroups)
 
 			ownerName := os.Getenv("CODER_WORKSPACE_OWNER_NAME")
+			if ownerName == "" {
+				ownerName = "default"
+			}
 			_ = rd.Set("owner_name", ownerName)
 
 			ownerID := os.Getenv("CODER_WORKSPACE_OWNER_ID")


### PR DESCRIPTION
Closes coder/modules#162

When the terraform plan is run, the `data.coder_workspace.me.owner_email` and `data.coder_workspace.me.owner_name` fields are blank, which causes the template build to fail. 

This should resolve the issue by setting those entries to a non-empty string.