### PR TITLE
chore!: remove deprecated feature_use_managed_variables

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,5 +62,4 @@ resource "google_compute_instance" "dev" {
 
 ### Optional
 
-- `feature_use_managed_variables` (Boolean, **Deprecated**: Terraform variables are now exclusively utilized for template-wide variables after the removal of support for legacy parameters.) Feature: use managed Terraform variables. The feature flag is not used anymore as Terraform variables are now exclusively utilized for template-wide variables.
 - `url` (String) The URL to access Coder.

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -35,13 +35,6 @@ func New() *schema.Provider {
 					return nil, nil
 				},
 			},
-			"feature_use_managed_variables": {
-				Type:        schema.TypeBool,
-				Description: "Feature: use managed Terraform variables. The feature flag is not used anymore as Terraform variables are now exclusively utilized for template-wide variables.",
-				Default:     true,
-				Optional:    true,
-				Deprecated:  "Terraform variables are now exclusively utilized for template-wide variables after the removal of support for legacy parameters.",
-			},
 		},
 		ConfigureContextFunc: func(c context.Context, resourceData *schema.ResourceData) (interface{}, diag.Diagnostics) {
 			rawURL, ok := resourceData.Get("url").(string)


### PR DESCRIPTION
The `feature_use_managed_variables` option has been removed as Terraform variables are now exclusively utilized for template-wide variables. This commit removes the deprecated option from the provider code.

contributes to #250 