### PR TITLE
ci: drop terraform versions < 1.5.x, add 1.9.x for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,15 +64,10 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - "1.0.*"
-          - "1.1.*"
-          - "1.2.*"
-          - "1.3.*"
-          - "1.4.*"
-          - "1.5.*"
           - "1.6.*"
           - "1.7.*"
           - "1.8.*"
+          - "1.9.*"
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -112,7 +107,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.3.*"
+          terraform_version: "latest"
           terraform_wrapper: false
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
+          - "1.5.*"
           - "1.6.*"
           - "1.7.*"
           - "1.8.*"


### PR DESCRIPTION
As per https://endoflife.date/terraform, only versions 1.8 and 1.9 are supported now. We can test from 1.5.x onwards for users who last upgraded about a year ago.