### PR TITLE
docs: add description to provider index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,10 +3,12 @@
 page_title: "Coder Provider"
 subcategory: "Infrastructure"
 description: |-
-  
+    Terraform provider for managing Coder templates, which are the underlying infrastructure for Coder workspaces.
 ---
 
 # Coder Provider
+
+CTerraform provider for managing Coder [templates](https://coder.com/docs/templates), which are the underlying infrastructure for Coder [workspaces](https://coder.com/docs/workspaces).
 
 ## Example
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ description: |-
 
 # Coder Provider
 
-CTerraform provider for managing Coder [templates](https://coder.com/docs/templates), which are the underlying infrastructure for Coder [workspaces](https://coder.com/docs/workspaces).
+Terraform provider for managing Coder [templates](https://coder.com/docs/templates), which are the underlying infrastructure for Coder [workspaces](https://coder.com/docs/workspaces).
 
 ## Example
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -3,10 +3,12 @@
 page_title: "Coder Provider"
 subcategory: "Infrastructure"
 description: |-
-  
+    Terraform provider for managing Coder templates, which are the underlying infrastructure for Coder workspaces.
 ---
 
 # Coder Provider
+
+Terraform provider for managing Coder [templates](https://coder.com/docs/templates), which are the underlying infrastructure for Coder [workspaces](https://coder.com/docs/workspaces).
 
 ## Example
 


### PR DESCRIPTION
This pull request adds a description to the provider index page. 
Closes #270