### PR TITLE
feat: add 'hidden' field to 'coder_app' provider

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -63,6 +63,7 @@ resource "coder_app" "vim" {
 - `display_name` (String) A display name to identify the app. Defaults to the slug.
 - `external` (Boolean) Specifies whether `url` is opened on the client machine instead of proxied through the workspace.
 - `healthcheck` (Block Set, Max: 1) HTTP health checking to determine the application readiness. (see [below for nested schema](#nestedblock--healthcheck))
+- `hidden` (Boolean) Determines if the app is visible in the UI.
 - `icon` (String) A URL to an icon that will display in the dashboard. View built-in icons here: https://github.com/coder/coder/tree/main/site/static/icon. Use a built-in icon with `"${data.coder_workspace.me.access_url}/icon/<path>"`.
 - `order` (Number) The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order).
 - `share` (String) Determines the level which the application is shared at. Valid levels are `"owner"` (default), `"authenticated"` and `"public"`. Level `"owner"` disables sharing on the app, so only the workspace owner can access it. Level `"authenticated"` shares the app with all authenticated users. Level `"public"` shares it with any user, including unauthenticated users. Permitted application sharing levels can be configured site-wide via a flag on `coder server` (Enterprise only).

--- a/integration/coder-app-hidden/main.tf
+++ b/integration/coder-app-hidden/main.tf
@@ -1,0 +1,62 @@
+terraform {
+  required_providers {
+    coder = {
+      source = "coder/coder"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+}
+
+data "coder_workspace" "me" {}
+
+resource "coder_agent" "dev" {
+  os   = "linux"
+  arch = "amd64"
+  dir  = "/workspace"
+}
+
+resource "coder_app" "hidden" {
+  agent_id = coder_agent.dev.id
+  slug     = "hidden"
+  share    = "owner"
+  hidden   = true
+}
+
+resource "coder_app" "visible" {
+  agent_id = coder_agent.dev.id
+  slug     = "visible"
+  share    = "owner"
+  hidden   = false
+}
+
+resource "coder_app" "defaulted" {
+  agent_id = coder_agent.dev.id
+  slug     = "defaulted"
+  share    = "owner"
+}
+
+locals {
+  # NOTE: these must all be strings in the output
+  output = {
+    "coder_app.hidden.hidden"    = tostring(coder_app.hidden.hidden)
+    "coder_app.visible.hidden"   = tostring(coder_app.visible.hidden)
+    "coder_app.defaulted.hidden" = tostring(coder_app.defaulted.hidden)
+  }
+}
+
+variable "output_path" {
+  type = string
+}
+
+resource "local_file" "output" {
+  filename = var.output_path
+  content  = jsonencode(local.output)
+}
+
+output "output" {
+  value     = local.output
+  sensitive = true
+}
+

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -112,6 +112,15 @@ func TestIntegration(t *testing.T) {
 				"workspace_owner.ssh_public_key":    `(?s)^ssh-ed25519.+$`,
 			},
 		},
+		{
+			name:       "coder-app-hidden",
+			minVersion: "v0.0.0",
+			expectedOutput: map[string]string{
+				"coder_app.hidden.hidden":    "true",
+				"coder_app.visible.hidden":   "false",
+				"coder_app.defaulted.hidden": "false",
+			},
+		},
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {

--- a/provider/app.go
+++ b/provider/app.go
@@ -187,6 +187,13 @@ func appResource() *schema.Resource {
 				ForceNew:    true,
 				Optional:    true,
 			},
+			"hidden": {
+				Type:        schema.TypeBool,
+				Description: "Determines if the app is visible in the UI.",
+				Default:     false,
+				ForceNew:    true,
+				Optional:    true,
+			},
 		},
 	}
 }

--- a/provider/app.go
+++ b/provider/app.go
@@ -30,7 +30,36 @@ func appResource() *schema.Resource {
 		Description: "Use this resource to define shortcuts to access applications in a workspace.",
 		CreateContext: func(c context.Context, resourceData *schema.ResourceData, i interface{}) diag.Diagnostics {
 			resourceData.SetId(uuid.NewString())
-			return nil
+
+			diags := diag.Diagnostics{}
+
+			hiddenData := resourceData.Get("hidden")
+			if hidden, ok := hiddenData.(bool); !ok {
+				return diag.Errorf("hidden should be a bool")
+			} else if hidden {
+				if _, ok := resourceData.GetOk("display_name"); ok {
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Warning,
+						Summary:  "`display_name` set when app is hidden",
+					})
+				}
+
+				if _, ok := resourceData.GetOk("icon"); ok {
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Warning,
+						Summary:  "`icon` set when app is hidden",
+					})
+				}
+
+				if _, ok := resourceData.GetOk("order"); ok {
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Warning,
+						Summary:  "`order` set when app is hidden",
+					})
+				}
+			}
+
+			return diags
 		},
 		ReadContext: func(c context.Context, resourceData *schema.ResourceData, i interface{}) diag.Diagnostics {
 			return nil

--- a/provider/app_test.go
+++ b/provider/app_test.go
@@ -45,6 +45,7 @@ func TestApp(t *testing.T) {
 						threshold = 6
 					}
 					order = 4
+					hidden = false
 				}
 				`,
 				Check: func(state *terraform.State) error {
@@ -66,6 +67,7 @@ func TestApp(t *testing.T) {
 						"healthcheck.0.interval",
 						"healthcheck.0.threshold",
 						"order",
+						"hidden",
 					} {
 						value := resource.Primary.Attributes[key]
 						t.Logf("%q = %q", key, value)
@@ -246,4 +248,75 @@ func TestApp(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("Hidden", func(t *testing.T) {
+		t.Parallel()
+
+		cases := []struct {
+			name   string
+			config string
+			hidden bool
+		}{{
+			name: "Is Hidden",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "https://google.com"
+				external = true
+				hidden = true
+			}
+			`,
+			hidden: true,
+		}, {
+			name: "Is Not Hidden",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "https://google.com"
+				external = true
+				hidden = false
+			}
+			`,
+			hidden: false,
+		}}
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				resource.Test(t, resource.TestCase{
+					Providers: map[string]*schema.Provider{
+						"coder": provider.New(),
+					},
+					IsUnitTest: true,
+					Steps: []resource.TestStep{{
+						Config: tc.config,
+						Check: func(state *terraform.State) error {
+							require.Len(t, state.Modules, 1)
+							require.Len(t, state.Modules[0].Resources, 2)
+							resource := state.Modules[0].Resources["coder_app.test"]
+							require.NotNil(t, resource)
+							require.Equal(t, strconv.FormatBool(tc.hidden), resource.Primary.Attributes["hidden"])
+							return nil
+						},
+						ExpectError: nil,
+					}},
+				})
+			})
+		}
+	})
+
 }


### PR DESCRIPTION
Relates to https://github.com/coder/coder/pull/14570

Adds a `hidden` field to the `coder_app` provider.