### PR TITLE
fix: validate agent & resource metadata keys during plan

### DIFF
--- a/provider/agent_test.go
+++ b/provider/agent_test.go
@@ -254,6 +254,7 @@ func TestAgent_MetadataDuplicateKeys(t *testing.T) {
 				}
 				`,
 			ExpectError: regexp.MustCompile("duplicate agent metadata key"),
+			PlanOnly:    true,
 		}},
 	})
 }
@@ -281,7 +282,7 @@ func TestAgent_DisplayApps(t *testing.T) {
 							web_terminal = false
 							port_forwarding_helper = false
 							ssh_helper = false
-						} 
+						}
 					}
 					`,
 				Check: func(state *terraform.State) error {
@@ -331,7 +332,7 @@ func TestAgent_DisplayApps(t *testing.T) {
 						display_apps {
 							vscode_insiders = true
 							web_terminal = true
-						} 
+						}
 					}
 					`,
 				Check: func(state *terraform.State) error {
@@ -426,7 +427,7 @@ func TestAgent_DisplayApps(t *testing.T) {
 							web_terminal = false
 							port_forwarding_helper = false
 							ssh_helper = false
-						} 
+						}
 					}
 					`,
 				ExpectError: regexp.MustCompile(`An argument named "fake_app" is not expected here.`),

--- a/provider/metadata_test.go
+++ b/provider/metadata_test.go
@@ -123,7 +123,8 @@ func TestMetadataDuplicateKeys(t *testing.T) {
 					}
 				}
 				`,
-			ExpectError: regexp.MustCompile("duplicate metadata key"),
+			PlanOnly:    true,
+			ExpectError: regexp.MustCompile("duplicate resource metadata key"),
 		}},
 	})
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -97,14 +97,8 @@ func populateIsNull(resourceData *schema.ResourceData) (result interface{}, err 
 	items := rawPlan.GetAttr("item").AsValueSlice()
 
 	var resultItems []interface{}
-	itemKeys := map[string]struct{}{}
 	for _, item := range items {
 		key := valueAsString(item.GetAttr("key"))
-		_, exists := itemKeys[key]
-		if exists {
-			return nil, xerrors.Errorf("duplicate metadata key %q", key)
-		}
-		itemKeys[key] = struct{}{}
 		resultItem := map[string]interface{}{
 			"key":       key,
 			"value":     valueAsString(item.GetAttr("value")),


### PR DESCRIPTION
Closes https://github.com/coder/coder/issues/14387.
Closes https://github.com/coder/coder/issues/14569.

Previously, the configuration had to be applied in order for the provider to complain about duplicate keys - now just a plan will suffice.