### PR TITLE
fix: optional everyone group in integration test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -103,7 +103,7 @@ func TestIntegration(t *testing.T) {
 				"workspace.transition":              `start`,
 				"workspace_owner.email":             `testing@coder\.com`,
 				"workspace_owner.full_name":         `default`,
-				"workspace_owner.groups":            `\[\]`,
+				"workspace_owner.groups":            `\[(\"Everyone\")?\]`,
 				"workspace_owner.id":                `[a-zA-Z0-9-]+`,
 				"workspace_owner.name":              `testing`,
 				"workspace_owner.oidc_access_token": `^$`, // TODO: test OIDC integration


### PR DESCRIPTION
CI is currently failing and blocking PRs as the integration test running against Coder v2.15.0 (mainline) adds the "Everyone" group to the `workspace_owner` `groups` field. However, the CI also runs the integration test against Coder v2.14.2 (stable), which doesn't include the everyone group. 

We'll accept either an empty groups list, or a list with the everyone group to enable running the test against both versions.