### PR TITLE
backport(fix): validate agent & resource metadata keys during plan

### DIFF
--- a/provider/agent.go
+++ b/provider/agent.go
@@ -43,18 +43,6 @@ func agentResource() *schema.Resource {
 				}
 			}
 
-			rawPlan := resourceData.GetRawPlan()
-			items := rawPlan.GetAttr("metadata").AsValueSlice()
-			itemKeys := map[string]struct{}{}
-			for _, item := range items {
-				key := valueAsString(item.GetAttr("key"))
-				_, exists := itemKeys[key]
-				if exists {
-					return diag.FromErr(xerrors.Errorf("duplicate agent metadata key %q", key))
-				}
-				itemKeys[key] = struct{}{}
-			}
-
 			return updateInitScript(resourceData, i)
 		},
 		ReadWithoutTimeout: func(ctx context.Context, resourceData *schema.ResourceData, i interface{}) diag.Diagnostics {
@@ -306,6 +294,32 @@ func agentResource() *schema.Resource {
 				ForceNew:    true,
 				Optional:    true,
 			},
+		},
+		CustomizeDiff: func(ctx context.Context, rd *schema.ResourceDiff, i any) error {
+			if !rd.HasChange("metadata") {
+				return nil
+			}
+
+			keys := map[string]bool{}
+			metadata, ok := rd.Get("metadata").([]any)
+			if !ok {
+				return xerrors.Errorf("unexpected type %T for metadata, expected []any", rd.Get("metadata"))
+			}
+			for _, t := range metadata {
+				obj, ok := t.(map[string]any)
+				if !ok {
+					return xerrors.Errorf("unexpected type %T for metadata, expected map[string]any", t)
+				}
+				key, ok := obj["key"].(string)
+				if !ok {
+					return xerrors.Errorf("unexpected type %T for metadata key, expected string", obj["key"])
+				}
+				if keys[key] {
+					return xerrors.Errorf("duplicate agent metadata key %q", key)
+				}
+				keys[key] = true
+			}
+			return nil
 		},
 	}
 }

--- a/provider/agent_test.go
+++ b/provider/agent_test.go
@@ -286,6 +286,7 @@ func TestAgent_MetadataDuplicateKeys(t *testing.T) {
 				}
 				`,
 			ExpectError: regexp.MustCompile("duplicate agent metadata key"),
+			PlanOnly:    true,
 		}},
 	})
 }
@@ -313,7 +314,7 @@ func TestAgent_DisplayApps(t *testing.T) {
 							web_terminal = false
 							port_forwarding_helper = false
 							ssh_helper = false
-						} 
+						}
 					}
 					`,
 				Check: func(state *terraform.State) error {
@@ -363,7 +364,7 @@ func TestAgent_DisplayApps(t *testing.T) {
 						display_apps {
 							vscode_insiders = true
 							web_terminal = true
-						} 
+						}
 					}
 					`,
 				Check: func(state *terraform.State) error {
@@ -458,7 +459,7 @@ func TestAgent_DisplayApps(t *testing.T) {
 							web_terminal = false
 							port_forwarding_helper = false
 							ssh_helper = false
-						} 
+						}
 					}
 					`,
 				ExpectError: regexp.MustCompile(`An argument named "fake_app" is not expected here.`),

--- a/provider/metadata_test.go
+++ b/provider/metadata_test.go
@@ -123,7 +123,8 @@ func TestMetadataDuplicateKeys(t *testing.T) {
 					}
 				}
 				`,
-			ExpectError: regexp.MustCompile("duplicate metadata key"),
+			PlanOnly:    true,
+			ExpectError: regexp.MustCompile("duplicate resource metadata key"),
 		}},
 	})
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -105,14 +105,8 @@ func populateIsNull(resourceData *schema.ResourceData) (result interface{}, err 
 	items := rawPlan.GetAttr("item").AsValueSlice()
 
 	var resultItems []interface{}
-	itemKeys := map[string]struct{}{}
 	for _, item := range items {
 		key := valueAsString(item.GetAttr("key"))
-		_, exists := itemKeys[key]
-		if exists {
-			return nil, xerrors.Errorf("duplicate metadata key %q", key)
-		}
-		itemKeys[key] = struct{}{}
 		resultItem := map[string]interface{}{
 			"key":       key,
 			"value":     valueAsString(item.GetAttr("value")),


### PR DESCRIPTION
Backports #277 to `release/1.0`