### PR TITLE
docs: document minimum version required for 'hidden' attribute

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -63,7 +63,7 @@ resource "coder_app" "vim" {
 - `display_name` (String) A display name to identify the app. Defaults to the slug.
 - `external` (Boolean) Specifies whether `url` is opened on the client machine instead of proxied through the workspace.
 - `healthcheck` (Block Set, Max: 1) HTTP health checking to determine the application readiness. (see [below for nested schema](#nestedblock--healthcheck))
-- `hidden` (Boolean) Determines if the app is visible in the UI (minimum coder version: v2.16).
+- `hidden` (Boolean) Determines if the app is visible in the UI (minimum Coder version: v2.16).
 - `icon` (String) A URL to an icon that will display in the dashboard. View built-in icons here: https://github.com/coder/coder/tree/main/site/static/icon. Use a built-in icon with `"${data.coder_workspace.me.access_url}/icon/<path>"`.
 - `order` (Number) The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order).
 - `share` (String) Determines the level which the application is shared at. Valid levels are `"owner"` (default), `"authenticated"` and `"public"`. Level `"owner"` disables sharing on the app, so only the workspace owner can access it. Level `"authenticated"` shares the app with all authenticated users. Level `"public"` shares it with any user, including unauthenticated users. Permitted application sharing levels can be configured site-wide via a flag on `coder server` (Enterprise only).

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -63,7 +63,7 @@ resource "coder_app" "vim" {
 - `display_name` (String) A display name to identify the app. Defaults to the slug.
 - `external` (Boolean) Specifies whether `url` is opened on the client machine instead of proxied through the workspace.
 - `healthcheck` (Block Set, Max: 1) HTTP health checking to determine the application readiness. (see [below for nested schema](#nestedblock--healthcheck))
-- `hidden` (Boolean) Determines if the app is visible in the UI.
+- `hidden` (Boolean) Determines if the app is visible in the UI (minimum coder version: v2.16).
 - `icon` (String) A URL to an icon that will display in the dashboard. View built-in icons here: https://github.com/coder/coder/tree/main/site/static/icon. Use a built-in icon with `"${data.coder_workspace.me.access_url}/icon/<path>"`.
 - `order` (Number) The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order).
 - `share` (String) Determines the level which the application is shared at. Valid levels are `"owner"` (default), `"authenticated"` and `"public"`. Level `"owner"` disables sharing on the app, so only the workspace owner can access it. Level `"authenticated"` shares the app with all authenticated users. Level `"public"` shares it with any user, including unauthenticated users. Permitted application sharing levels can be configured site-wide via a flag on `coder server` (Enterprise only).

--- a/provider/app.go
+++ b/provider/app.go
@@ -218,7 +218,7 @@ func appResource() *schema.Resource {
 			},
 			"hidden": {
 				Type:        schema.TypeBool,
-				Description: "Determines if the app is visible in the UI.",
+				Description: "Determines if the app is visible in the UI (minimum coder version: v2.16).",
 				Default:     false,
 				ForceNew:    true,
 				Optional:    true,

--- a/provider/app.go
+++ b/provider/app.go
@@ -218,7 +218,7 @@ func appResource() *schema.Resource {
 			},
 			"hidden": {
 				Type:        schema.TypeBool,
-				Description: "Determines if the app is visible in the UI (minimum coder version: v2.16).",
+				Description: "Determines if the app is visible in the UI (minimum Coder version: v2.16).",
 				Default:     false,
 				ForceNew:    true,
 				Optional:    true,


### PR DESCRIPTION
Document the minimum version of coder required for the 'hidden' attribute.