### PR TITLE
Add login_type to coder_workspace_owner data source #235

### DIFF
--- a/docs/data-sources/workspace_owner.md
+++ b/docs/data-sources/workspace_owner.md
@@ -50,9 +50,9 @@ resource "coder_env" "git_author_email" {
 - `full_name` (String) The full name of the user.
 - `groups` (List of String) The groups of which the user is a member.
 - `id` (String) The UUID of the workspace owner.
+- `login_type` (String) The type of login the user has.
 - `name` (String) The username of the user.
 - `oidc_access_token` (String) A valid OpenID Connect access token of the workspace owner. This is only available if the workspace owner authenticated with OpenID Connect. If a valid token cannot be obtained, this value will be an empty string.
 - `session_token` (String) Session token for authenticating with a Coder deployment. It is regenerated every time a workspace is started.
 - `ssh_private_key` (String, Sensitive) The user's generated SSH private key.
 - `ssh_public_key` (String) The user's generated SSH public key.
-- `login_type` (String) The user's login type. The valid options are `password`, `github`, `oidc` or `none`.

--- a/docs/data-sources/workspace_owner.md
+++ b/docs/data-sources/workspace_owner.md
@@ -55,3 +55,4 @@ resource "coder_env" "git_author_email" {
 - `session_token` (String) Session token for authenticating with a Coder deployment. It is regenerated every time a workspace is started.
 - `ssh_private_key` (String, Sensitive) The user's generated SSH private key.
 - `ssh_public_key` (String) The user's generated SSH public key.
+- `login_type` (String) The user's login type. The valid options are `password`, `github`, `oidc` or `none`.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -112,7 +112,7 @@ func TestIntegration(t *testing.T) {
 				"workspace_owner.session_token":     `.+`,
 				"workspace_owner.ssh_private_key":   `(?s)^.+?BEGIN OPENSSH PRIVATE KEY.+?END OPENSSH PRIVATE KEY.+?$`,
 				"workspace_owner.ssh_public_key":    `(?s)^ssh-ed25519.+$`,
-				"workspace_owner.login_type":        `none`,
+				"workspace_owner.login_type":        ``,
 			},
 		},
 		{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -112,6 +112,7 @@ func TestIntegration(t *testing.T) {
 				"workspace_owner.session_token":     `.+`,
 				"workspace_owner.ssh_private_key":   `(?s)^.+?BEGIN OPENSSH PRIVATE KEY.+?END OPENSSH PRIVATE KEY.+?$`,
 				"workspace_owner.ssh_public_key":    `(?s)^ssh-ed25519.+$`,
+				"workspace_owner.login_type":        `none`,
 			},
 		},
 		{

--- a/integration/workspace-owner/main.tf
+++ b/integration/workspace-owner/main.tf
@@ -39,6 +39,7 @@ locals {
     "workspace_owner.session_token" : data.coder_workspace_owner.me.session_token,
     "workspace_owner.ssh_private_key" : data.coder_workspace_owner.me.ssh_private_key,
     "workspace_owner.ssh_public_key" : data.coder_workspace_owner.me.ssh_public_key,
+    "workspace_owner.login_type" : data.coder_workspace_owner.me.login_type,
   }
 }
 

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -54,11 +54,15 @@ func workspaceOwnerDataSource() *schema.Resource {
 			_ = rd.Set("oidc_access_token", os.Getenv("CODER_WORKSPACE_OWNER_OIDC_ACCESS_TOKEN"))
 
 			if os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE") == "" {
-				diag.Warn("The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set")
+				diags := req.Config.Get(ctx, &rd)
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summmary: "WARNING: The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set"
+				},
 			}
 			_ = rd.Set("login_type", os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE"))
 
-			return nil
+			return diags
 		},
 		Schema: map[string]*schema.Schema{
 			"id": {

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -58,7 +58,7 @@ func workspaceOwnerDataSource() *schema.Resource {
 			if os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE") == "" {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
-					Summmary: "WARNING: The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set"
+					Summmary: "WARNING: The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set",
 				},
 			}
 			_ = rd.Set("login_type", os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE"))

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -59,7 +59,7 @@ func workspaceOwnerDataSource() *schema.Resource {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
 					Summmary: "WARNING: The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set",
-				},
+				})
 			}
 			_ = rd.Set("login_type", os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE"))
 

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -58,7 +58,7 @@ func workspaceOwnerDataSource() *schema.Resource {
 			if os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE") == "" {
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
-					Summmary: "WARNING: The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set",
+					Summary: "WARNING: The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set",
 				})
 			}
 			_ = rd.Set("login_type", os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE"))

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -53,11 +53,7 @@ func workspaceOwnerDataSource() *schema.Resource {
 			_ = rd.Set("session_token", os.Getenv("CODER_WORKSPACE_OWNER_SESSION_TOKEN"))
 			_ = rd.Set("oidc_access_token", os.Getenv("CODER_WORKSPACE_OWNER_OIDC_ACCESS_TOKEN"))
 
-			if login_type := os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE"); login_type != "" {
-				_ = rd.Set("login_type", login_type)
-			} else {
-				_ = rd.Set("login_type", "none")
-			}
+			_ = rd.Set("login_type", os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE"))
 
 			return nil
 		},

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -3,9 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"os"
-	"slices"
 	"strings"
 
 	"github.com/google/uuid"
@@ -55,12 +53,7 @@ func workspaceOwnerDataSource() *schema.Resource {
 			_ = rd.Set("session_token", os.Getenv("CODER_WORKSPACE_OWNER_SESSION_TOKEN"))
 			_ = rd.Set("oidc_access_token", os.Getenv("CODER_WORKSPACE_OWNER_OIDC_ACCESS_TOKEN"))
 
-			types := []string{"password", "github", "oidc", "none"}
 			if login_type := os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE"); login_type != "" {
-				if !slices.Contains(types, login_type) {
-					errorMessage := "invalid login type: %s, the valid types are: 'password, github, oidc, or none'"
-					return diag.Errorf(errorMessage, errors.New(errorMessage))
-				}
 				_ = rd.Set("login_type", login_type)
 			} else {
 				_ = rd.Set("login_type", "none")

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -53,6 +53,9 @@ func workspaceOwnerDataSource() *schema.Resource {
 			_ = rd.Set("session_token", os.Getenv("CODER_WORKSPACE_OWNER_SESSION_TOKEN"))
 			_ = rd.Set("oidc_access_token", os.Getenv("CODER_WORKSPACE_OWNER_OIDC_ACCESS_TOKEN"))
 
+			if os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE") == "" {
+				diag.Warn("The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set")
+			}
 			_ = rd.Set("login_type", os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE"))
 
 			return nil

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -15,6 +15,8 @@ func workspaceOwnerDataSource() *schema.Resource {
 	return &schema.Resource{
 		Description: "Use this data source to fetch information about the workspace owner.",
 		ReadContext: func(ctx context.Context, rd *schema.ResourceData, i interface{}) diag.Diagnostics {
+			diags := diag.Diagnostics{}
+
 			if idStr := os.Getenv("CODER_WORKSPACE_OWNER_ID"); idStr != "" {
 				rd.SetId(idStr)
 			} else {
@@ -54,7 +56,6 @@ func workspaceOwnerDataSource() *schema.Resource {
 			_ = rd.Set("oidc_access_token", os.Getenv("CODER_WORKSPACE_OWNER_OIDC_ACCESS_TOKEN"))
 
 			if os.Getenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE") == "" {
-				diags := req.Config.Get(ctx, &rd)
 				diags = append(diags, diag.Diagnostic{
 					Severity: diag.Warning,
 					Summmary: "WARNING: The CODER_WORKSPACE_OWNER_LOGIN_TYPE env variable is not set"

--- a/provider/workspace_owner_test.go
+++ b/provider/workspace_owner_test.go
@@ -35,6 +35,7 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 		t.Setenv("CODER_WORKSPACE_OWNER_GROUPS", `["group1", "group2"]`)
 		t.Setenv("CODER_WORKSPACE_OWNER_SESSION_TOKEN", `supersecret`)
 		t.Setenv("CODER_WORKSPACE_OWNER_OIDC_ACCESS_TOKEN", `alsosupersecret`)
+		t.Setenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE", `github`)
 
 		resource.Test(t, resource.TestCase{
 			Providers: map[string]*schema.Provider{
@@ -63,6 +64,8 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 					assert.Equal(t, `group2`, attrs["groups.1"])
 					assert.Equal(t, `supersecret`, attrs["session_token"])
 					assert.Equal(t, `alsosupersecret`, attrs["oidc_access_token"])
+					assert.Equal(t, `github`, attrs["login_type"])
+
 					return nil
 				},
 			}},
@@ -80,6 +83,7 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 			"CODER_WORKSPACE_OWNER_OIDC_ACCESS_TOKEN",
 			"CODER_WORKSPACE_OWNER_SSH_PUBLIC_KEY",
 			"CODER_WORKSPACE_OWNER_SSH_PRIVATE_KEY",
+			"CODER_WORKSPACE_OWNER_LOGIN_TYPE",
 		} { // https://github.com/golang/go/issues/52817
 			t.Setenv(v, "")
 			os.Unsetenv(v)
@@ -111,6 +115,7 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 					assert.Empty(t, attrs["groups.0"])
 					assert.Empty(t, attrs["session_token"])
 					assert.Empty(t, attrs["oidc_access_token"])
+					assert.Equal(t, "none", attrs["login_type"])
 					return nil
 				},
 			}},

--- a/provider/workspace_owner_test.go
+++ b/provider/workspace_owner_test.go
@@ -115,7 +115,7 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 					assert.Empty(t, attrs["groups.0"])
 					assert.Empty(t, attrs["session_token"])
 					assert.Empty(t, attrs["oidc_access_token"])
-					assert.Equal(t, "none", attrs["login_type"])
+					assert.Empty(t, attrs["login_type"])
 					return nil
 				},
 			}},


### PR DESCRIPTION
This PR add the login type the the `coder_workspace_owner` data source (Issue #235).

I took some decisions (like the default value to `none`), but if you think this should be different please let me know.

Thanks! 