### PR TITLE
fix(.goreleaser.yml): use semver to sort git tags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -61,3 +61,5 @@ changelog:
   use: github-native
   sort: asc
   abbrev: 0
+git:
+  tag_sort: semver


### PR DESCRIPTION
See: https://github.com/goreleaser/goreleaser/issues/4134