### PR TITLE
chore: update paths to /v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/coder/terraform-provider-coder
+module github.com/coder/terraform-provider-coder/v2
 
 go 1.22.9
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/coder/terraform-provider-coder/provider"
+	"github.com/coder/terraform-provider-coder/v2/provider"
 )
 
 // Run the docs generation tool, check its repository for more information on how it works and how docs

--- a/provider/agent.go
+++ b/provider/agent.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/terraform-provider-coder/provider/helpers"
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 )
 
 func agentResource() *schema.Resource {

--- a/provider/decode_test.go
+++ b/provider/decode_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/terraform-provider-coder/provider"
+	"github.com/coder/terraform-provider-coder/v2/provider"
 )
 
 func TestDecode(t *testing.T) {

--- a/provider/externalauth.go
+++ b/provider/externalauth.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/coder/terraform-provider-coder/provider/helpers"
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 )
 
 // externalAuthDataSource returns a schema for an external authentication data source.

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/terraform-provider-coder/provider"
+	"github.com/coder/terraform-provider-coder/v2/provider"
 )
 
 func TestParameter(t *testing.T) {

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/terraform-provider-coder/provider"
+	"github.com/coder/terraform-provider-coder/v2/provider"
 )
 
 func TestProvider(t *testing.T) {

--- a/provider/workspace.go
+++ b/provider/workspace.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/coder/terraform-provider-coder/provider/helpers"
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 )
 
 func workspaceDataSource() *schema.Resource {

--- a/scripts/docsgen/main.go
+++ b/scripts/docsgen/main.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/coder/terraform-provider-coder/provider"
+	"github.com/coder/terraform-provider-coder/v2/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"golang.org/x/xerrors"
 )


### PR DESCRIPTION
We forgot to update the import paths when releasing v2! Doing so now as we'll probably need to import v2 of the provider in `coder/coder` eventually.