### PR TITLE
feat: add `rbac_roles` to `coder_workspace_owner` data source

### DIFF
--- a/docs/data-sources/workspace_owner.md
+++ b/docs/data-sources/workspace_owner.md
@@ -53,6 +53,7 @@ resource "coder_env" "git_author_email" {
 - `login_type` (String) The type of login the user has.
 - `name` (String) The username of the user.
 - `oidc_access_token` (String) A valid OpenID Connect access token of the workspace owner. This is only available if the workspace owner authenticated with OpenID Connect. If a valid token cannot be obtained, this value will be an empty string.
+- `rbac_roles` (List of Map) The RBAC roles and associated org ids of which the user is assigned.
 - `session_token` (String) Session token for authenticating with a Coder deployment. It is regenerated every time a workspace is started.
 - `ssh_private_key` (String, Sensitive) The user's generated SSH private key.
 - `ssh_public_key` (String) The user's generated SSH public key.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -113,6 +113,7 @@ func TestIntegration(t *testing.T) {
 				"workspace_owner.ssh_private_key":   `(?s)^.+?BEGIN OPENSSH PRIVATE KEY.+?END OPENSSH PRIVATE KEY.+?$`,
 				"workspace_owner.ssh_public_key":    `(?s)^ssh-ed25519.+$`,
 				"workspace_owner.login_type":        ``,
+				"workspace_owner.rbac_roles":        `\[\]`,
 			},
 		},
 		{
@@ -141,6 +142,7 @@ func TestIntegration(t *testing.T) {
 				"workspace_owner.ssh_private_key":   `(?s)^.+?BEGIN OPENSSH PRIVATE KEY.+?END OPENSSH PRIVATE KEY.+?$`,
 				"workspace_owner.ssh_public_key":    `(?s)^ssh-ed25519.+$`,
 				"workspace_owner.login_type":        `password`,
+				"workspace_owner.rbac_roles":        `\[\]`,
 			},
 		},
 		{

--- a/integration/workspace-owner-filled/main.tf
+++ b/integration/workspace-owner-filled/main.tf
@@ -40,6 +40,7 @@ locals {
     "workspace_owner.ssh_private_key" : data.coder_workspace_owner.me.ssh_private_key,
     "workspace_owner.ssh_public_key" : data.coder_workspace_owner.me.ssh_public_key,
     "workspace_owner.login_type" : data.coder_workspace_owner.me.login_type,
+    "workspace_owner.rbac_roles" : jsonencode(data.coder_workspace_owner.me.rbac_roles),
   }
 }
 

--- a/integration/workspace-owner/main.tf
+++ b/integration/workspace-owner/main.tf
@@ -40,6 +40,7 @@ locals {
     "workspace_owner.ssh_private_key" : data.coder_workspace_owner.me.ssh_private_key,
     "workspace_owner.ssh_public_key" : data.coder_workspace_owner.me.ssh_public_key,
     "workspace_owner.login_type" : data.coder_workspace_owner.me.login_type,
+    "workspace_owner.rbac_roles" : jsonencode(data.coder_workspace_owner.me.rbac_roles),
   }
 }
 

--- a/provider/workspace_owner.go
+++ b/provider/workspace_owner.go
@@ -59,6 +59,14 @@ func workspaceOwnerDataSource() *schema.Resource {
 				_ = rd.Set("login_type", loginType)
 			}
 
+			var rbacRoles []map[string]string
+			if rolesRaw, ok := os.LookupEnv("CODER_WORKSPACE_OWNER_RBAC_ROLES"); ok {
+				if err := json.NewDecoder(strings.NewReader(rolesRaw)).Decode(&rbacRoles); err != nil {
+					return diag.Errorf("invalid user rbac roles: %s", err.Error())
+				}
+			}
+			_ = rd.Set("rbac_roles", rbacRoles)
+
 			return diags
 		},
 		Schema: map[string]*schema.Schema{
@@ -117,6 +125,25 @@ func workspaceOwnerDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The type of login the user has.",
+			},
+			"rbac_roles": {
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the RBAC role.",
+						},
+						"org_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The organization ID associated with the RBAC role.",
+						},
+					},
+				},
+				Computed:    true,
+				Description: "The RBAC roles of which the user is assigned.",
 			},
 		},
 	}

--- a/provider/workspace_owner_test.go
+++ b/provider/workspace_owner_test.go
@@ -34,6 +34,7 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 		t.Setenv("CODER_WORKSPACE_OWNER_SESSION_TOKEN", `supersecret`)
 		t.Setenv("CODER_WORKSPACE_OWNER_OIDC_ACCESS_TOKEN", `alsosupersecret`)
 		t.Setenv("CODER_WORKSPACE_OWNER_LOGIN_TYPE", `github`)
+		t.Setenv("CODER_WORKSPACE_OWNER_RBAC_ROLES", `[{"name":"member","org_id":"00000000-0000-0000-0000-000000000000"}]`)
 
 		resource.Test(t, resource.TestCase{
 			ProviderFactories: coderFactory(),
@@ -61,7 +62,8 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 					assert.Equal(t, `supersecret`, attrs["session_token"])
 					assert.Equal(t, `alsosupersecret`, attrs["oidc_access_token"])
 					assert.Equal(t, `github`, attrs["login_type"])
-
+					assert.Equal(t, `member`, attrs["rbac_roles.0.name"])
+					assert.Equal(t, `00000000-0000-0000-0000-000000000000`, attrs["rbac_roles.0.org_id"])
 					return nil
 				},
 			}},
@@ -80,6 +82,7 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 			"CODER_WORKSPACE_OWNER_SSH_PUBLIC_KEY",
 			"CODER_WORKSPACE_OWNER_SSH_PRIVATE_KEY",
 			"CODER_WORKSPACE_OWNER_LOGIN_TYPE",
+			"CODER_WORKSPACE_OWNER_RBAC_ROLES",
 		} { // https://github.com/golang/go/issues/52817
 			t.Setenv(v, "")
 			os.Unsetenv(v)
@@ -110,6 +113,7 @@ func TestWorkspaceOwnerDatasource(t *testing.T) {
 					assert.Empty(t, attrs["session_token"])
 					assert.Empty(t, attrs["oidc_access_token"])
 					assert.Empty(t, attrs["login_type"])
+					assert.Empty(t, attrs["rbac_roles.0"])
 					return nil
 				},
 			}},


### PR DESCRIPTION
This PR updates the schema for the coder_workspace_owner data source to expose rbac_roles.

It's very similar to https://github.com/coder/terraform-provider-coder/pull/287

Relevant `coder/coder` PR - https://github.com/coder/coder/pull/16407