### PR TITLE
ci: drop support for EOL terraform version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,11 +88,8 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - "1.5.*"
-          - "1.6.*"
-          - "1.7.*"
-          - "1.8.*"
           - "1.9.*"
+          - "1.10.*"
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Drop support for EOL terraform versions. 
We upgraded to terraform 1.9 in Coder 2.14.x 7 months ago, which is no longer supported.

Also includes terraform 1.10