### PR TITLE
fix: app display name validation

### DIFF
--- a/provider/app.go
+++ b/provider/app.go
@@ -23,6 +23,8 @@ var (
 	appSlugRegex = regexp.MustCompile(`^[a-z0-9](-?[a-z0-9])*$`)
 )
 
+const appDisplayNameMaxLength = 64 // database column limit
+
 func appResource() *schema.Resource {
 	return &schema.Resource{
 		SchemaVersion: 1,
@@ -124,6 +126,17 @@ func appResource() *schema.Resource {
 				Description: "A display name to identify the app. Defaults to the slug.",
 				ForceNew:    true,
 				Optional:    true,
+				ValidateDiagFunc: func(val interface{}, c cty.Path) diag.Diagnostics {
+					valStr, ok := val.(string)
+					if !ok {
+						return diag.Errorf("expected string, got %T", val)
+					}
+
+					if len(valStr) > appDisplayNameMaxLength {
+						return diag.Errorf("display name is too long (max %d characters)", appDisplayNameMaxLength)
+					}
+					return nil
+				},
 			},
 			"subdomain": {
 				Type: schema.TypeBool,

--- a/provider/app_test.go
+++ b/provider/app_test.go
@@ -433,6 +433,10 @@ func TestApp(t *testing.T) {
 				displayName: "Regular Application",
 			},
 			{
+				name:        "DisplayNameStillOK",
+				displayName: "0123456789012345678901234567890123456789012345678901234567890123",
+			},
+			{
 				name:        "DisplayNameTooLong",
 				displayName: "01234567890123456789012345678901234567890123456789012345678901234",
 				expectError: regexp.MustCompile("display name is too long"),


### PR DESCRIPTION
Fixes: https://github.com/coder/terraform-provider-coder/issues/307

This PR enables basic validation for app display name: `coder_app` has database a constraint on the column length.