### PR TITLE
fix: support unlimited parameter options

### DIFF
--- a/docs/data-sources/parameter.md
+++ b/docs/data-sources/parameter.md
@@ -147,7 +147,7 @@ data "coder_parameter" "home_volume_size" {
 - `ephemeral` (Boolean) The value of an ephemeral parameter will not be preserved between consecutive workspace builds.
 - `icon` (String) A URL to an icon that will display in the dashboard. View built-in icons [here](https://github.com/coder/coder/tree/main/site/static/icon). Use a built-in icon with `"${data.coder_workspace.me.access_url}/icon/<path>"`.
 - `mutable` (Boolean) Whether this value can be changed after workspace creation. This can be destructive for values like region, so use with caution!
-- `option` (Block List, Max: 64) Each `option` block defines a value for a user to select from. (see [below for nested schema](#nestedblock--option))
+- `option` (Block List) Each `option` block defines a value for a user to select from. (see [below for nested schema](#nestedblock--option))
 - `order` (Number) The order determines the position of a template parameter in the UI/CLI presentation. The lowest order is shown first and parameters with equal order are sorted by name (ascending order).
 - `type` (String) The type of this parameter. Must be one of: `"number"`, `"string"`, `"bool"`, or `"list(string)"`.
 - `validation` (Block List, Max: 1) Validate the input of a parameter. (see [below for nested schema](#nestedblock--validation))

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -237,7 +237,6 @@ func parameterDataSource() *schema.Resource {
 				Description: "Each `option` block defines a value for a user to select from.",
 				ForceNew:    true,
 				Optional:    true,
-				MaxItems:    64,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {


### PR DESCRIPTION
Fixes: https://github.com/coder/terraform-provider-coder/issues/161

In coder/coder there is [no limitation](https://github.com/coder/coder/blob/d52d2397ea2c2fdb8636b966e3f45a0e26b7529d/coderd/database/dump.sql#L1215C1-L1235C1) for parameter options, and there is no real objective to have this limited enforced in terraform-provider-coder. This PR relaxes the constraint.

_I'm doing some spring cleanup around old issues._