### PR TITLE
chore: test auto prerelease

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,6 +56,8 @@ release:
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
+  prerelease: auto
+  make_latest: "{{ not .Prerelease }}"
 changelog:
   # see https://goreleaser.com/customization/changelog/
   use: github-native

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,7 +57,7 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
   prerelease: auto
-  make_latest: "{{ not .Prerelease }}"
+  make_latest: {{ eq (.Prerelease | len) 0 }}
 changelog:
   # see https://goreleaser.com/customization/changelog/
   use: github-native

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,7 +57,7 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
   prerelease: auto
-  make_latest: {{ eq (.Prerelease | len) 0 }}
+  make_latest: {{ not .Prerelease }}
 changelog:
   # see https://goreleaser.com/customization/changelog/
   use: github-native


### PR DESCRIPTION
This configures goreleaser to automate prereleases when we push a tag that contains `pre` or `rc`
Ref: https://goreleaser.com/customization/release/#github