### PR TITLE
chore: do not use GitHub prereleases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,10 +55,6 @@ release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
-  prerelease: auto
-  make_latest: '{{ not .Prerelease }}'
 changelog:
   # see https://goreleaser.com/customization/changelog/
   use: github-native


### PR DESCRIPTION
Removes automatic handling of GitHub releases.
For some reason, the registry isn't recognizing new tags, and we suspect this might not be the cause.