### PR TITLE
chore: only release if tests pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
 
   goreleaser:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
We've generally been lucky that builds are slower than integration tests, but we need explicit ordering here