### PR TITLE
chore: change OptionType to alias for usage as string

### DIFF
--- a/provider/formtype.go
+++ b/provider/formtype.go
@@ -13,7 +13,7 @@ import (
 //
 // The value have to be string literals, as type constraint keywords are not
 // supported in providers.
-type OptionType string
+type OptionType = string
 
 const (
 	OptionTypeString     OptionType = "string"


### PR DESCRIPTION
To be backwards compatible using this repo as a library, use a string alias. This allows using the 'type' as a `string` or the new enum. Since enum validation is quite weak in Go, this is baiscally functionally equvialent.

This fixes a compile time issue in `coder/coder` when using the latest of this repo.