### PR TITLE
feat: parameter validation refactored to single function

### DIFF
--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -24,9 +24,14 @@ import (
 type ValidationMode string
 
 const (
-	// ValidationModeDefault is used for creating a workspace. It validates the
-	// final value used for a parameter.
-	ValidationModeDefault        ValidationMode = ""
+	// ValidationModeDefault is used for creating a workspace. It validates the final
+	// value used for a parameter. Some allowances for invalid options are tolerated,
+	// as unused options do not affect the final parameter value. The default value
+	// is also ignored, assuming a value is provided.
+	ValidationModeDefault ValidationMode = ""
+	// ValidationModeTemplateImport tolerates empty values, as the value might not be
+	// available at import. It does not tolerate an invalid default or invalid option
+	// values.
 	ValidationModeTemplateImport ValidationMode = "template-import"
 )
 
@@ -412,6 +417,14 @@ func (v *Parameter) Valid(input *string, mode ValidationMode) (string, diag.Diag
 	if input == nil {
 		value = v.Default
 	}
+
+	// TODO: When empty values want to be rejected, uncomment this.
+	//   coder/coder should update to use template import mode first,
+	//   before this is uncommented.
+	//if value == nil && mode == ValidationModeDefault {
+	//	var empty string
+	//	value = &empty
+	//}
 
 	// optionType might differ from parameter.Type. This is ok, and parameter.Type
 	// should be used for the value type, and optionType for options.

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -525,7 +525,7 @@ func (v *Parameter) validValue(value string, optionType OptionType, optionValues
 						Severity:      diag.Error,
 						Summary:       "When using list(string) type, value must be a json encoded list of strings",
 						Detail:        err.Error(),
-						AttributePath: defaultValuePath,
+						AttributePath: path,
 					},
 				}
 			}
@@ -548,7 +548,7 @@ func (v *Parameter) validValue(value string, optionType OptionType, optionValues
 							"%s %q is not a valid option, values %q are missing from the options",
 							name, value, strings.Join(missing, ", "),
 						),
-						AttributePath: defaultValuePath,
+						AttributePath: path,
 					},
 				}
 			}

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -24,6 +24,7 @@ import (
 type ValidationMode string
 
 const (
+	ValidationModeEnvVar = "CODER_VALIDATION_MODE"
 	// ValidationModeDefault is used for creating a workspace. It validates the final
 	// value used for a parameter. Some allowances for invalid options are tolerated,
 	// as unused options do not affect the final parameter value. The default value
@@ -59,7 +60,6 @@ type Validation struct {
 }
 
 const (
-	ValidationModeEnvVar          = "CODER_VALIDATION_MODE"
 	ValidationMonotonicIncreasing = "increasing"
 	ValidationMonotonicDecreasing = "decreasing"
 )

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -161,7 +161,7 @@ func parameterDataSource() *schema.Resource {
 			}
 
 			mode := os.Getenv(ValidationModeEnvVar)
-			value, diags := parameter.Valid(input, ValidationMode(mode))
+			value, diags := parameter.ValidateInput(input, ValidationMode(mode))
 			if diags.HasError() {
 				return diags
 			}
@@ -410,7 +410,7 @@ func valueIsType(typ OptionType, value string) error {
 	return nil
 }
 
-func (v *Parameter) Valid(input *string, mode ValidationMode) (string, diag.Diagnostics) {
+func (v *Parameter) ValidateInput(input *string, mode ValidationMode) (string, diag.Diagnostics) {
 	if mode != ValidationModeDefault && mode != ValidationModeTemplateImport {
 		return "", diag.Diagnostics{
 			{

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -142,21 +142,24 @@ func parameterDataSource() *schema.Resource {
 			// 'parameter.FormType' value to the new value. This is to handle default cases,
 			// since the default logic is more advanced than the sdk provider schema
 			// supports.
-			_, newFT, err := ValidateFormType(parameter.Type, len(parameter.Option), parameter.FormType)
-			if err == nil {
-				// If there is an error, parameter.Valid will catch it.
-				parameter.FormType = newFT
-
-				// Set the form_type back in case the value was changed.
-				// Eg via a default. If a user does not specify, a default value
-				// is used and saved.
-				rd.Set("form_type", parameter.FormType)
-			}
+			//_, newFT, err := ValidateFormType(parameter.Type, len(parameter.Option), parameter.FormType)
+			//if err == nil {
+			//	// If there is an error, parameter.Valid will catch it.
+			//	parameter.FormType = newFT
+			//
+			//	// Set the form_type back in case the value was changed.
+			//	// Eg via a default. If a user does not specify, a default value
+			//	// is used and saved.
+			//	rd.Set("form_type", parameter.FormType)
+			//}
 
 			diags := parameter.Valid(value)
 			if diags.HasError() {
 				return diags
 			}
+
+			// Set the form_type as it could have changed in the validation.
+			rd.Set("form_type", parameter.FormType)
 
 			return nil
 		},
@@ -393,6 +396,11 @@ func valueIsType(typ OptionType, value string) error {
 	default:
 		return fmt.Errorf("invalid type %q", typ)
 	}
+	return nil
+}
+
+func (v *Parameter) RelaxedValidation(value string) diag.Diagnostics {
+
 	return nil
 }
 

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -544,10 +544,14 @@ func (v *Parameter) validValue(value string, optionType OptionType, optionValues
 		} else {
 			_, isValid := optionValues[value]
 			if !isValid {
+				extra := ""
+				if value == "" {
+					extra = ". The value is empty, did you forget to set it with a default or from user input?"
+				}
 				return diag.Diagnostics{
 					{
 						Severity:      diag.Error,
-						Summary:       fmt.Sprintf("%s must be a valid option", name),
+						Summary:       fmt.Sprintf("%s must be a valid option%s", name, extra),
 						Detail:        fmt.Sprintf("the value %q must be defined as one of options", value),
 						AttributePath: path,
 					},

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -866,10 +866,6 @@ func TestParameterValidationEnforcement(t *testing.T) {
 	// - Validation logic does not apply to the default if a value is given
 	//	- [NumIns/DefInv] So the default can be invalid if an input value is valid.
 	//	  The value is therefore not really optional, but it is marked as such.
-	// - [NumInsNotOptsVal | NumsInsNotOpts] values do not need to be in the option set?
-	// - [NumInsNotNum] number params do not require the value to be a number
-	// - [LStrInsNotList] list(string) do not require the value to be a list(string)
-	//	- Same with [MulInsNotListOpts]
 	table, err := os.ReadFile("testdata/parameter_table.md")
 	require.NoError(t, err)
 

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -786,7 +786,7 @@ func TestParameterValidation(t *testing.T) {
 			Name: "NotListStringDefault",
 			Parameter: provider.Parameter{
 				Type:    "list(string)",
-				Default: "not-a-list",
+				Default: ptr("not-a-list"),
 			},
 			ExpectError: regexp.MustCompile("not a valid list of strings"),
 		},
@@ -802,7 +802,7 @@ func TestParameterValidation(t *testing.T) {
 			Name: "DefaultListStringNotInOptions",
 			Parameter: provider.Parameter{
 				Type:     "list(string)",
-				Default:  `["red", "yellow", "black"]`,
+				Default:  ptr(`["red", "yellow", "black"]`),
 				Option:   opts("red", "blue", "green"),
 				FormType: provider.ParameterFormTypeMultiSelect,
 			},
@@ -813,7 +813,7 @@ func TestParameterValidation(t *testing.T) {
 			Name: "ListStringNotInOptions",
 			Parameter: provider.Parameter{
 				Type:     "list(string)",
-				Default:  `["red"]`,
+				Default:  ptr(`["red"]`),
 				Option:   opts("red", "blue", "green"),
 				FormType: provider.ParameterFormTypeMultiSelect,
 			},
@@ -824,7 +824,7 @@ func TestParameterValidation(t *testing.T) {
 			Name: "InvalidMiniumum",
 			Parameter: provider.Parameter{
 				Type:    "number",
-				Default: "5",
+				Default: ptr("5"),
 				Validation: []provider.Validation{{
 					Min:   10,
 					Error: "must be greater than 10",
@@ -837,7 +837,7 @@ func TestParameterValidation(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			value := &tc.Value
-			diags := tc.Parameter.Valid(value)
+			_, diags := tc.Parameter.Valid(value, provider.ValidationModeDefault)
 			if tc.ExpectError != nil {
 				require.True(t, diags.HasError())
 				errMsg := fmt.Sprintf("%+v", diags[0]) // close enough
@@ -1254,4 +1254,8 @@ func TestParameterWithManyOptions(t *testing.T) {
 			},
 		}},
 	})
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -806,6 +806,7 @@ func TestParameterValidation(t *testing.T) {
 				Option:   opts("red", "blue", "green"),
 				FormType: provider.ParameterFormTypeMultiSelect,
 			},
+			Value:       `["red", "yellow", "black"]`,
 			ExpectError: regexp.MustCompile("is not a valid option, values \"yellow, black\" are missing from the options"),
 		},
 		{
@@ -835,7 +836,8 @@ func TestParameterValidation(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			diags := tc.Parameter.Valid(&tc.Value)
+			value := &tc.Value
+			diags := tc.Parameter.Valid(value)
 			if tc.ExpectError != nil {
 				require.True(t, diags.HasError())
 				errMsg := fmt.Sprintf("%+v", diags[0]) // close enough

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -839,7 +839,7 @@ func TestParameterValidation(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			value := &tc.Value
-			_, diags := tc.Parameter.Valid(value, provider.ValidationModeDefault)
+			_, diags := tc.Parameter.ValidateInput(value, provider.ValidationModeDefault)
 			if tc.ExpectError != nil {
 				require.True(t, diags.HasError())
 				errMsg := fmt.Sprintf("%+v", diags[0]) // close enough

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -946,6 +946,15 @@ func TestParameterValidation(t *testing.T) {
 			ExpectError: regexp.MustCompile("Value must be a valid option"),
 		},
 		{
+			Name: "NumberNotInOptions",
+			Parameter: provider.Parameter{
+				Type:   "number",
+				Option: opts("1", "2", "3"),
+			},
+			Value:       "0", // not in option set
+			ExpectError: regexp.MustCompile("Value must be a valid option"),
+		},
+		{
 			Name: "NonUniqueOptionNames",
 			Parameter: provider.Parameter{
 				Type:   "string",
@@ -982,6 +991,55 @@ func TestParameterValidation(t *testing.T) {
 			},
 			Value:       "not-a-number",
 			ExpectError: regexp.MustCompile("Parameter value is not of type \"number\""),
+		},
+		{
+			Name: "NotListStringDefault",
+			Parameter: provider.Parameter{
+				Type:    "list(string)",
+				Default: "not-a-list",
+			},
+			ExpectError: regexp.MustCompile("not a valid list of strings"),
+		},
+		{
+			Name: "NotListStringDefault",
+			Parameter: provider.Parameter{
+				Type: "list(string)",
+			},
+			Value:       "not-a-list",
+			ExpectError: regexp.MustCompile("not a valid list of strings"),
+		},
+		{
+			Name: "DefaultListStringNotInOptions",
+			Parameter: provider.Parameter{
+				Type:     "list(string)",
+				Default:  `["red", "yellow", "black"]`,
+				Option:   opts("red", "blue", "green"),
+				FormType: provider.ParameterFormTypeMultiSelect,
+			},
+			ExpectError: regexp.MustCompile("is not a valid option, values \"yellow, black\" are missing from the options"),
+		},
+		{
+			Name: "ListStringNotInOptions",
+			Parameter: provider.Parameter{
+				Type:     "list(string)",
+				Default:  `["red"]`,
+				Option:   opts("red", "blue", "green"),
+				FormType: provider.ParameterFormTypeMultiSelect,
+			},
+			Value:       `["red", "yellow", "black"]`,
+			ExpectError: regexp.MustCompile("is not a valid option, values \"yellow, black\" are missing from the options"),
+		},
+		{
+			Name: "InvalidMiniumum",
+			Parameter: provider.Parameter{
+				Type:    "number",
+				Default: "5",
+				Validation: []provider.Validation{{
+					Min:   10,
+					Error: "must be greater than 10",
+				}},
+			},
+			ExpectError: regexp.MustCompile("must be greater than 10"),
 		},
 	} {
 		tc := tc

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -878,7 +878,8 @@ func TestParameterValidationEnforcement(t *testing.T) {
 		Validation  *provider.Validation
 		OutputValue string
 		Optional    bool
-		Error       *regexp.Regexp
+		CreateError *regexp.Regexp
+		ImportError *regexp.Regexp
 	}
 
 	rows := make([]row, 0)
@@ -909,6 +910,19 @@ func TestParameterValidationEnforcement(t *testing.T) {
 				t.Fatalf("failed to parse error column %q: %v", columns[9], err)
 			}
 		}
+
+		var imerr *regexp.Regexp
+		if columns[10] != "" {
+			if columns[10] == "=" {
+				imerr = rerr
+			} else {
+				imerr, err = regexp.Compile(columns[10])
+				if err != nil {
+					t.Fatalf("failed to parse error column %q: %v", columns[10], err)
+				}
+			}
+		}
+
 		var options []string
 		if columns[4] != "" {
 			options = strings.Split(columns[4], ",")
@@ -955,7 +969,8 @@ func TestParameterValidationEnforcement(t *testing.T) {
 			Validation:  validation,
 			OutputValue: columns[7],
 			Optional:    optional,
-			Error:       rerr,
+			CreateError: rerr,
+			ImportError: imerr,
 		})
 	}
 
@@ -974,9 +989,9 @@ func TestParameterValidationEnforcement(t *testing.T) {
 					t.Setenv(provider.ParameterEnvironmentVariable("parameter"), row.InputValue)
 				}
 
-				if row.Error != nil {
+				if row.CreateError != nil && row.ImportError != nil {
 					if row.OutputValue != "" {
-						t.Errorf("output value %q should not be set if error is set", row.OutputValue)
+						t.Errorf("output value %q should not be set if both errors are set", row.OutputValue)
 					}
 				}
 
@@ -1020,42 +1035,56 @@ func TestParameterValidationEnforcement(t *testing.T) {
 
 				cfg.WriteString("}\n")
 
-				resource.Test(t, resource.TestCase{
-					ProviderFactories: coderFactory(),
-					IsUnitTest:        true,
-					Steps: []resource.TestStep{{
-						Config:      cfg.String(),
-						ExpectError: row.Error,
-						Check: func(state *terraform.State) error {
-							require.Len(t, state.Modules, 1)
-							require.Len(t, state.Modules[0].Resources, 1)
-							param := state.Modules[0].Resources["data.coder_parameter.parameter"]
-							require.NotNil(t, param)
+				for _, mode := range []provider.ValidationMode{provider.ValidationModeDefault, provider.ValidationModeTemplateImport} {
+					name := string(mode)
+					if mode == provider.ValidationModeDefault {
+						name = "create"
+					}
+					t.Run(name, func(t *testing.T) {
+						t.Setenv("CODER_VALIDATION_MODE", string(mode))
+						rerr := row.CreateError
+						if mode == provider.ValidationModeTemplateImport {
+							rerr = row.ImportError
+						}
 
-							if row.Default == "" {
-								_, ok := param.Primary.Attributes["default"]
-								require.False(t, ok, "default should not be set")
-							} else {
-								require.Equal(t, strings.Trim(row.Default, `"`), param.Primary.Attributes["default"])
-							}
+						resource.Test(t, resource.TestCase{
+							ProviderFactories: coderFactory(),
+							IsUnitTest:        true,
+							Steps: []resource.TestStep{{
+								Config:      cfg.String(),
+								ExpectError: rerr,
+								Check: func(state *terraform.State) error {
+									require.Len(t, state.Modules, 1)
+									require.Len(t, state.Modules[0].Resources, 1)
+									param := state.Modules[0].Resources["data.coder_parameter.parameter"]
+									require.NotNil(t, param)
 
-							if row.OutputValue == "" {
-								_, ok := param.Primary.Attributes["value"]
-								require.False(t, ok, "output value should not be set")
-							} else {
-								require.Equal(t, strings.Trim(row.OutputValue, `"`), param.Primary.Attributes["value"])
-							}
+									if row.Default == "" {
+										_, ok := param.Primary.Attributes["default"]
+										require.False(t, ok, "default should not be set")
+									} else {
+										require.Equal(t, strings.Trim(row.Default, `"`), param.Primary.Attributes["default"])
+									}
 
-							for key, expected := range map[string]string{
-								"optional": strconv.FormatBool(row.Optional),
-							} {
-								require.Equal(t, expected, param.Primary.Attributes[key], "optional")
-							}
+									if row.OutputValue == "" {
+										_, ok := param.Primary.Attributes["value"]
+										require.False(t, ok, "output value should not be set")
+									} else {
+										require.Equal(t, strings.Trim(row.OutputValue, `"`), param.Primary.Attributes["value"])
+									}
 
-							return nil
-						},
-					}},
-				})
+									for key, expected := range map[string]string{
+										"optional": strconv.FormatBool(row.Optional),
+									} {
+										require.Equal(t, expected, param.Primary.Attributes[key], "optional")
+									}
+
+									return nil
+								},
+							}},
+						})
+					})
+				}
 			})
 		}
 	}

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -835,7 +835,7 @@ func TestParameterValidation(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
-			diags := tc.Parameter.Valid(tc.Value)
+			diags := tc.Parameter.Valid(&tc.Value)
 			if tc.ExpectError != nil {
 				require.True(t, diags.HasError())
 				errMsg := fmt.Sprintf("%+v", diags[0]) // close enough

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -85,6 +85,7 @@ func TestParameter(t *testing.T) {
 			data "coder_parameter" "region" {
 				name = "Region"
 				type = "number"
+				default = 1
 				option {
 					name = "1"
 					value = "1"
@@ -102,6 +103,7 @@ func TestParameter(t *testing.T) {
 			data "coder_parameter" "region" {
 				name = "Region"
 				type = "string"
+				default = "1"
 				option {
 					name = "1"
 					value = "1"

--- a/provider/testdata/parameter_table.md
+++ b/provider/testdata/parameter_table.md
@@ -1,80 +1,80 @@
-| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | ErrorCreate     | ErrorImport   |
-|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|-----------------|---------------|
-|                      | Empty Vals    |           |         |                   |            |    |        |          |                 |               |
-| Empty                | string,number |           |         |                   |            |    | ""     | false    |                 |               |
-| EmptyDupeOps         | string,number |           |         | 1,1,1             |            |    |        |          | unique          | =             |
-| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |                 |               |
-| EmptyListDupeOpts    | list(string)  |           |         | ["a"],["a"]       |            |    |        |          | unique          | =             |
-| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |                 |               |
-| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |                 |               |
-| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error     | =             |
-| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10       | =             |
-| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | valid option    | 2 < 1 < 5     |
-| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | valid option    | regex error   |
-| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |                 |               |
-|                      |               |           |         |                   |            |    |        |          |                 |               |
-|                      | Default Set   | No inputs |         |                   |            |    |        |          |                 |               |
-| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |                 |               |
-| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |                 |               |
-| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0      | =             |
-| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |                 | 2 < 1 < 6     |
-| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option    | 2 < 1 < 6     |
-| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10      | =             |
-| NumDefNotNum         | number        |           | a       |                   |            |    |        |          | type "number"   | =             |
-| NumDefOptsNotNum     | number        |           | 1       | 1,a,2             |            |    |        |          | type "number"   | =             |
-|                      |               |           |         |                   |            |    |        |          |                 |               |
-| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |                 |               |
-| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error     | =             |
-| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |                 |               |
-| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option    | =             |
-| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |                 | value "d"     |
-| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error     | =             |
-|                      |               |           |         |                   |            |    |        |          |                 |               |
-| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |               |
-| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |                 |               |
-| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option    | =             |
-|                      |               |           |         |                   |            |    |        |          |                 |               |
-| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |               |
-| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |                 |               |
-| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option    | =             |
-|                      |               |           |         |                   |            |    |        |          |                 |               |
-|                      | Input Vals    |           |         |                   |            |    |        |          |                 |               |
-| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |                 |               |
-| NumInsOptsNaN        | number        | 3         | 5       | a,1,2,3,4,5       | 1-3        |    |        |          | type "number"   | =             |
-| NumInsNotNum         | number        | a         |         |                   |            |    |        |          | type "number"   | =             |
-| NumInsNotNumInv      | number        | a         |         |                   | 1-3        |    |        |          | 1 < a < 3       | =             |
-| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |                 |               |
-| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |                 | 1 < 5 < 3     |
-| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3       | =             |
-| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |                 | 1 < 5 < 3     |
-| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option    | 1 < 4 < 3     |
-| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | valid option    | 1 < 4 < 2     |
-| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option    | =             |
-| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option    | =             |
-|                      |               |           |         |                   |            |    |        |          |                 |               |
-| StrIns               | string        | c         |         |                   |            |    | c      | false    |                 |               |
-| StrInsDupeOpts       | string        | c         |         | a,b,c,c           |            |    |        |          | unique          | =             |
-| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |                 |               |
-| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |                 | default value |
-| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error     | =             |
-| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |                 | value "d"     |
-| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option    | value "d"     |
-| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | valid option    | regex error   |
-| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option    | =             |
-| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option    | =             |
-| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot      | =             |
-|                      |               |           |         |                   |            |    |        |          |                 |               |
-|                      | list(string)  |           |         |                   |            |    |        |          |                 |               |
-| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |                 |               |
-| LStrInsNotList       | list(string)  | c         |         |                   |            |    |        |          | list of strings | =             |
-| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |                 |               |
-| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot    | =             |
-| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |                 |               |
-| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option    | =             |
-| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option    | =             |
-|                      |               |           |         |                   |            |    |        |          |                 |               |
-| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |                 |               |
-| MulInsNotListOpts    | multi-select  | c         | ["e"]   | c,d,e             |            |    |        |          | json encoded    | =             |
-| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option    | =             |
-| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option    | =             |
-| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot    | =             |
+| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | ErrorCreate     |
+|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|-----------------|
+|                      | Empty Vals    |           |         |                   |            |    |        |          |                 |
+| Empty                | string,number |           |         |                   |            |    | ""     | false    |                 |
+| EmptyDupeOps         | string,number |           |         | 1,1,1             |            |    |        |          | unique          |
+| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |                 |
+| EmptyListDupeOpts    | list(string)  |           |         | ["a"],["a"]       |            |    |        |          | unique          |
+| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |                 |
+| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |                 |
+| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error     |
+| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10       |
+| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | valid option    |
+| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | valid option    |
+| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |                 |
+|                      |               |           |         |                   |            |    |        |          |                 |
+|                      | Default Set   | No inputs |         |                   |            |    |        |          |                 |
+| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |                 |
+| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |                 |
+| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0      |
+| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |                 |
+| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option    |
+| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10      |
+| NumDefNotNum         | number        |           | a       |                   |            |    |        |          | type "number"   |
+| NumDefOptsNotNum     | number        |           | 1       | 1,a,2             |            |    |        |          | type "number"   |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |                 |
+| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error     |
+| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |                 |
+| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option    |
+| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |                 |
+| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error     |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |
+| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |                 |
+| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option    |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |
+| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |                 |
+| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option    |
+|                      |               |           |         |                   |            |    |        |          |                 |
+|                      | Input Vals    |           |         |                   |            |    |        |          |                 |
+| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |                 |
+| NumInsOptsNaN        | number        | 3         | 5       | a,1,2,3,4,5       | 1-3        |    |        |          | type "number"   |
+| NumInsNotNum         | number        | a         |         |                   |            |    |        |          | type "number"   |
+| NumInsNotNumInv      | number        | a         |         |                   | 1-3        |    |        |          | 1 < a < 3       |
+| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |                 |
+| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |                 |
+| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3       |
+| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |                 |
+| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option    |
+| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | valid option    |
+| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option    |
+| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option    |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| StrIns               | string        | c         |         |                   |            |    | c      | false    |                 |
+| StrInsDupeOpts       | string        | c         |         | a,b,c,c           |            |    |        |          | unique          |
+| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |                 |
+| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |                 |
+| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error     |
+| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |                 |
+| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option    |
+| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | valid option    |
+| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option    |
+| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option    |
+| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot      |
+|                      |               |           |         |                   |            |    |        |          |                 |
+|                      | list(string)  |           |         |                   |            |    |        |          |                 |
+| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |                 |
+| LStrInsNotList       | list(string)  | c         |         |                   |            |    |        |          | list of strings |
+| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |                 |
+| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot    |
+| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |                 |
+| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option    |
+| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option    |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |                 |
+| MulInsNotListOpts    | multi-select  | c         | ["e"]   | c,d,e             |            |    |        |          | json encoded    |
+| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option    |
+| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option    |
+| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot    |

--- a/provider/testdata/parameter_table.md
+++ b/provider/testdata/parameter_table.md
@@ -1,80 +1,80 @@
-| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error         |
-|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|---------------|
-|                      | Empty Vals    |           |         |                   |            |    |        |          |               |
-| Empty                | string,number |           |         |                   |            |    | ""     | false    |               |
-| EmptyDupeOps         | string,number |           |         | 1,1,1             |            |    |        |          | unique        |
-| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |               |
-| EmptyListDupeOpts    | list(string)  |           |         | ["a"],["a"]       |            |    |        |          | unique        |
-| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |               |
-| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |               |
-| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error   |
-| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10     |
-| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5      |
-| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error   |
-| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |               |
-|                      |               |           |         |                   |            |    |        |          |               |
-|                      | Default Set   | No inputs |         |                   |            |    |        |          |               |
-| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |               |
-| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |               |
-| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0    |
-| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |               |
-| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option  |
-| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10    |
-| NumDefNotNum         | number        |           | a       |                   |            |    |        |          | type "number" |
-| NumDefOptsNotNum     | number        |           | 1       | 1,a,2             |            |    |        |          | type "number" |
-|                      |               |           |         |                   |            |    |        |          |               |
-| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |               |
-| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error   |
-| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |               |
-| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option  |
-| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |               |
-| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error   |
-|                      |               |           |         |                   |            |    |        |          |               |
-| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |               |
-| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |               |
-| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option  |
-|                      |               |           |         |                   |            |    |        |          |               |
-| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |               |
-| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |               |
-| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option  |
-|                      |               |           |         |                   |            |    |        |          |               |
-|                      | Input Vals    |           |         |                   |            |    |        |          |               |
-| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |               |
-| NumInsOptsNaN        | number        | 3         | 5       | a,1,2,3,4,5       | 1-3        |    | 3      | true     | type "number" |  
-| NumInsNotNum         | number        | a         |         |                   |            |    |        |          | type "number" |
-| NumInsNotNumInv      | number        | a         |         |                   | 1-3        |    |        |          | 1 < a < 3     |   
-| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |               |
-| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |               |
-| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3     |
-| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |               |
-| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option  |
-| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2     |
-| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option  |
-| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option  |
-|                      |               |           |         |                   |            |    |        |          |               |
-| StrIns               | string        | c         |         |                   |            |    | c      | false    |               |
-| StrInsDupeOpts       | string        | c         |         | a,b,c,c           |            |    |        |          | unique        |
-| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |               |
-| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |               |
-| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error   |
-| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |               |
-| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option  |
-| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error   |
-| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option  |
-| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option  |
-| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot    |
-|                      |               |           |         |                   |            |    |        |          |               |
-|                      | list(string)  |           |         |                   |            |    |        |          |               |
-| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |               |
-| LStrInsNotList       | list(string)  | c         |         |                   |            |    | c      | false    |               |
-| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |               |
-| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot  |
-| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |               |
-| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option  |
-| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option  |
-|                      |               |           |         |                   |            |    |        |          |               |
-| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |               |
-| MulInsNotListOpts    | multi-select  | c         | ["e"]   | c,d,e             |            |    | c      | true     |               |
-| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option  |
-| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option  |
-| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot  |
+| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error           |
+|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|-----------------|
+|                      | Empty Vals    |           |         |                   |            |    |        |          |                 |
+| Empty                | string,number |           |         |                   |            |    | ""     | false    |                 |
+| EmptyDupeOps         | string,number |           |         | 1,1,1             |            |    |        |          | unique          |
+| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |                 |
+| EmptyListDupeOpts    | list(string)  |           |         | ["a"],["a"]       |            |    |        |          | unique          |
+| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |                 |
+| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |                 |
+| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error     |
+| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10       |
+| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5        |
+| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error     |
+| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |                 |
+|                      |               |           |         |                   |            |    |        |          |                 |
+|                      | Default Set   | No inputs |         |                   |            |    |        |          |                 |
+| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |                 |
+| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |                 |
+| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0      |
+| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |                 |
+| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option    |
+| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10      |
+| NumDefNotNum         | number        |           | a       |                   |            |    |        |          | type "number"   |
+| NumDefOptsNotNum     | number        |           | 1       | 1,a,2             |            |    |        |          | type "number"   |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |                 |
+| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error     |
+| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |                 |
+| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option    |
+| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |                 |
+| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error     |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |
+| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |                 |
+| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option    |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |
+| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |                 |
+| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option    |
+|                      |               |           |         |                   |            |    |        |          |                 |
+|                      | Input Vals    |           |         |                   |            |    |        |          |                 |
+| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |                 |
+| NumInsOptsNaN        | number        | 3         | 5       | a,1,2,3,4,5       | 1-3        |    |        |          | type "number"   |  
+| NumInsNotNum         | number        | a         |         |                   |            |    |        |          | type "number"   |
+| NumInsNotNumInv      | number        | a         |         |                   | 1-3        |    |        |          | 1 < a < 3       |   
+| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |                 |
+| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |                 |
+| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3       |
+| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |                 |
+| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option    |
+| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2       |
+| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option    |
+| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option    |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| StrIns               | string        | c         |         |                   |            |    | c      | false    |                 |
+| StrInsDupeOpts       | string        | c         |         | a,b,c,c           |            |    |        |          | unique          |
+| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |                 |
+| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |                 |
+| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error     |
+| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |                 |
+| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option    |
+| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error     |
+| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option    |
+| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option    |
+| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot      |
+|                      |               |           |         |                   |            |    |        |          |                 |
+|                      | list(string)  |           |         |                   |            |    |        |          |                 |
+| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |                 |
+| LStrInsNotList       | list(string)  | c         |         |                   |            |    |        |          | list of strings |
+| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |                 |
+| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot    |
+| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |                 |
+| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option    |
+| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option    |
+|                      |               |           |         |                   |            |    |        |          |                 |
+| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |                 |
+| MulInsNotListOpts    | multi-select  | c         | ["e"]   | c,d,e             |            |    |        |          | json encoded    |
+| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option    |
+| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option    |
+| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot    |

--- a/provider/testdata/parameter_table.md
+++ b/provider/testdata/parameter_table.md
@@ -1,70 +1,73 @@
-| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error        |
-|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|--------------|
-|                      | Empty Vals    |           |         |                   |            |    |        |          |              |
-| Empty                | string,number |           |         |                   |            |    | ""     | false    |              |
-| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |              |
-| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |              |
-| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |              |
-| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error  |
-| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10    |
-| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5     |
-| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error  |
-| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |              |
-|                      |               |           |         |                   |            |    |        |          |              |
-|                      | Default Set   | No inputs |         |                   |            |    |        |          |              |
-| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |              |
-| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |              |
-| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0   |
-| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |              |
-| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option |
-| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10   |
-|                      |               |           |         |                   |            |    |        |          |              |
-| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |              |
-| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error  |
-| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |              |
-| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option |
-| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |              |
-| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error  |
-|                      |               |           |         |                   |            |    |        |          |              |
-| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |              |
-| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |              |
-| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option |
-|                      |               |           |         |                   |            |    |        |          |              |
-| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |              |
-| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |              |
-| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option |
-|                      |               |           |         |                   |            |    |        |          |              |
-|                      | Input Vals    |           |         |                   |            |    |        |          |              |
-| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |              |
-| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |              |
-| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |              |
-| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3    |
-| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |              |
-| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option |
-| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2    |
-| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option |
-| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option |
-|                      |               |           |         |                   |            |    |        |          |              |
-| StrIns               | string        | c         |         |                   |            |    | c      | false    |              |
-| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |              |
-| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |              |
-| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error  |
-| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |              |
-| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option |
-| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error  |
-| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option |
-| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option |
-| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot   |
-|                      |               |           |         |                   |            |    |        |          |              |
-|                      | list(string)  |           |         |                   |            |    |        |          |              |
-| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |              |
-| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |              |
-| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot |
-| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |              |
-| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option |
-| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option |
-|                      |               |           |         |                   |            |    |        |          |              |
-| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |              |
-| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option |
-| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option |
-| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot |
+| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error         |
+|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|---------------|
+|                      | Empty Vals    |           |         |                   |            |    |        |          |               |
+| Empty                | string,number |           |         |                   |            |    | ""     | false    |               |
+| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |               |
+| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |               |
+| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |               |
+| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error   |
+| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10     |
+| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5      |
+| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error   |
+| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |               |
+|                      |               |           |         |                   |            |    |        |          |               |
+|                      | Default Set   | No inputs |         |                   |            |    |        |          |               |
+| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |               |
+| NumDefNaN            | number        |           | a       |                   |            |    |        |          | type "number" |   
+| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |               |
+| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0    |
+| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |               |
+| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option  |
+| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10    |
+|                      |               |           |         |                   |            |    |        |          |               |
+| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |               |
+| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error   |
+| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |               |
+| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option  |
+| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |               |
+| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error   |
+|                      |               |           |         |                   |            |    |        |          |               |
+| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |               |
+| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |               |
+| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option  |
+|                      |               |           |         |                   |            |    |        |          |               |
+| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |               |
+| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |               |
+| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option  |
+|                      |               |           |         |                   |            |    |        |          |               |
+|                      | Input Vals    |           |         |                   |            |    |        |          |               |
+| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |               |
+| NumInsOptsNaN        | number        | 3         | 5       | a,1,2,3,4,5       | 1-3        |    | 3      | true     | type "number" |  
+| NumInsNaN            | number        | a         |         |                   |            |    |        |          | type "number" |      
+| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |               |
+| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |               |
+| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3     |
+| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |               |
+| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option  |
+| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2     |
+| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option  |
+| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option  |
+|                      |               |           |         |                   |            |    |        |          |               |
+| StrIns               | string        | c         |         |                   |            |    | c      | false    |               |
+| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |               |
+| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |               |
+| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error   |
+| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |               |
+| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option  |
+| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error   |
+| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option  |
+| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option  |
+| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot    |
+|                      |               |           |         |                   |            |    |        |          |               |
+|                      | list(string)  |           |         |                   |            |    |        |          |               |
+| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |               |
+| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |               |
+| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot  |
+| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |               |
+| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option  |
+| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option  |
+|                      |               |           |         |                   |            |    |        |          |               |
+| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |               |
+| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option  |
+| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option  |
+| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot  |

--- a/provider/testdata/parameter_table.md
+++ b/provider/testdata/parameter_table.md
@@ -1,70 +1,70 @@
-| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error        |
-|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|--------------|
-|                      | Empty Vals    |           |         |                   |            |    |        |          |              |
-| Empty                | string,number |           |         |                   |            |    | ""     | false    |              |
-| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |              |
-| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |              |
-| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |              |
-| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error  |
-| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10    |
-| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5     |
-| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error  |
-| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |              |
-|                      |               |           |         |                   |            |    |        |          |              |
-|                      | Default Set   | No inputs |         |                   |            |    |        |          |              |
-| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |              |
-| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |              |
-| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0   |
-| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |              |
-| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option |
-| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10   |
-|                      |               |           |         |                   |            |    |        |          |              |
-| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |              |
-| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error  |
-| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |              |
-| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option |
-| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |              |
-| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error  |
-|                      |               |           |         |                   |            |    |        |          |              |
-| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |              |
-| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |              |
-| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option |
-|                      |               |           |         |                   |            |    |        |          |              |
-| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |              |
-| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |              |
-| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option |
-|                      |               |           |         |                   |            |    |        |          |              |
-|                      | Input Vals    |           |         |                   |            |    |        |          |              |
-| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |              |
-| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |              |
-| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |              |
-| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3    |
-| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |              |
-| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    | 3      | true     |              |
-| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2    |
-| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    | 3      | true     |              |
-| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    | 3      | false    |              |
-|                      |               |           |         |                   |            |    |        |          |              |
-| StrIns               | string        | c         |         |                   |            |    | c      | false    |              |
-| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |              |
-| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |              |
-| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error  |
-| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |              |
-| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    | c      | true     |              |
-| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error  |
-| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    | c      | true     |              |
-| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    | c      | false    |              |
-| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot   |
-|                      |               |           |         |                   |            |    |        |          |              |
-|                      | list(string)  |           |         |                   |            |    |        |          |              |
-| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |              |
-| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |              |
-| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot |
-| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |              |
-| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    | ["c"]  | true     |              |
-| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    | ["c"]  | false    |              |
-|                      |               |           |         |                   |            |    |        |          |              |
-| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |              |
-| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    | ["c"]  | true     |              |
-| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    | ["c"]  | false    |              |
-| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot |
+| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error         |
+|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|---------------|
+|                      | Empty Vals    |           |         |                   |            |    |        |          |               |
+| Empty                | string,number |           |         |                   |            |    | ""     | false    |               |
+| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |               |
+| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |               |
+| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |               |
+| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error   |
+| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10     |
+| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5      |
+| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error   |
+| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |               |
+|                      |               |           |         |                   |            |    |        |          |               |
+|                      | Default Set   | No inputs |         |                   |            |    |        |          |               |
+| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |               |
+| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |               |
+| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0    |
+| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |               |
+| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option  |
+| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10    |
+|                      |               |           |         |                   |            |    |        |          |               |
+| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |               |
+| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error   |
+| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |               |
+| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option  |
+| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |               |
+| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error   |
+|                      |               |           |         |                   |            |    |        |          |               |
+| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |               |
+| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |               |
+| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option  |
+|                      |               |           |         |                   |            |    |        |          |               |
+| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |               |
+| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |               |
+| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option  |
+|                      |               |           |         |                   |            |    |        |          |               |
+|                      | Input Vals    |           |         |                   |            |    |        |          |               |
+| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |               |
+| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |               |
+| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |               |
+| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3     |
+| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |               |
+| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option  |
+| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2     |
+| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option  |
+| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option  |
+|                      |               |           |         |                   |            |    |        |          |               |
+| StrIns               | string        | c         |         |                   |            |    | c      | false    |               |
+| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |               |
+| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |               |
+| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error   |
+| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |               |
+| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    | c      | true     |               |
+| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error   |
+| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    | c      | true     |               |
+| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    | c      | false    |               |
+| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot    |
+|                      |               |           |         |                   |            |    |        |          |               |
+|                      | list(string)  |           |         |                   |            |    |        |          |               |
+| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |               |
+| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |               |
+| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot  |
+| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |               |
+| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    | ["c"]  | true     |               |
+| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    | ["c"]  | false    |               |
+|                      |               |           |         |                   |            |    |        |          |               |
+| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |               |
+| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    | ["c"]  | true     |               |
+| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    | ["c"]  | false    |               |
+| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot  |

--- a/provider/testdata/parameter_table.md
+++ b/provider/testdata/parameter_table.md
@@ -1,80 +1,80 @@
-| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error           |
-|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|-----------------|
-|                      | Empty Vals    |           |         |                   |            |    |        |          |                 |
-| Empty                | string,number |           |         |                   |            |    | ""     | false    |                 |
-| EmptyDupeOps         | string,number |           |         | 1,1,1             |            |    |        |          | unique          |
-| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |                 |
-| EmptyListDupeOpts    | list(string)  |           |         | ["a"],["a"]       |            |    |        |          | unique          |
-| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |                 |
-| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |                 |
-| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error     |
-| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10       |
-| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5        |
-| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error     |
-| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |                 |
-|                      |               |           |         |                   |            |    |        |          |                 |
-|                      | Default Set   | No inputs |         |                   |            |    |        |          |                 |
-| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |                 |
-| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |                 |
-| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0      |
-| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |                 |
-| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option    |
-| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10      |
-| NumDefNotNum         | number        |           | a       |                   |            |    |        |          | type "number"   |
-| NumDefOptsNotNum     | number        |           | 1       | 1,a,2             |            |    |        |          | type "number"   |
-|                      |               |           |         |                   |            |    |        |          |                 |
-| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |                 |
-| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error     |
-| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |                 |
-| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option    |
-| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |                 |
-| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error     |
-|                      |               |           |         |                   |            |    |        |          |                 |
-| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |
-| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |                 |
-| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option    |
-|                      |               |           |         |                   |            |    |        |          |                 |
-| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |
-| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |                 |
-| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option    |
-|                      |               |           |         |                   |            |    |        |          |                 |
-|                      | Input Vals    |           |         |                   |            |    |        |          |                 |
-| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |                 |
-| NumInsOptsNaN        | number        | 3         | 5       | a,1,2,3,4,5       | 1-3        |    |        |          | type "number"   |  
-| NumInsNotNum         | number        | a         |         |                   |            |    |        |          | type "number"   |
-| NumInsNotNumInv      | number        | a         |         |                   | 1-3        |    |        |          | 1 < a < 3       |   
-| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |                 |
-| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |                 |
-| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3       |
-| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |                 |
-| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option    |
-| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2       |
-| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option    |
-| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option    |
-|                      |               |           |         |                   |            |    |        |          |                 |
-| StrIns               | string        | c         |         |                   |            |    | c      | false    |                 |
-| StrInsDupeOpts       | string        | c         |         | a,b,c,c           |            |    |        |          | unique          |
-| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |                 |
-| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |                 |
-| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error     |
-| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |                 |
-| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option    |
-| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error     |
-| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option    |
-| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option    |
-| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot      |
-|                      |               |           |         |                   |            |    |        |          |                 |
-|                      | list(string)  |           |         |                   |            |    |        |          |                 |
-| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |                 |
-| LStrInsNotList       | list(string)  | c         |         |                   |            |    |        |          | list of strings |
-| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |                 |
-| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot    |
-| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |                 |
-| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option    |
-| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option    |
-|                      |               |           |         |                   |            |    |        |          |                 |
-| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |                 |
-| MulInsNotListOpts    | multi-select  | c         | ["e"]   | c,d,e             |            |    |        |          | json encoded    |
-| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option    |
-| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option    |
-| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot    |
+| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | ErrorCreate     | ErrorImport   |
+|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|-----------------|---------------|
+|                      | Empty Vals    |           |         |                   |            |    |        |          |                 |               |
+| Empty                | string,number |           |         |                   |            |    | ""     | false    |                 |               |
+| EmptyDupeOps         | string,number |           |         | 1,1,1             |            |    |        |          | unique          | =             |
+| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |                 |               |
+| EmptyListDupeOpts    | list(string)  |           |         | ["a"],["a"]       |            |    |        |          | unique          | =             |
+| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |                 |               |
+| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |                 |               |
+| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error     | =             |
+| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10       | =             |
+| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5        | 2 < 1 < 5     |
+| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error     | =             |
+| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |                 |               |
+|                      |               |           |         |                   |            |    |        |          |                 |               |
+|                      | Default Set   | No inputs |         |                   |            |    |        |          |                 |               |
+| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |                 |               |
+| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |                 |               |
+| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0      | =             |
+| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |                 | 2 < 1 < 6     |
+| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option    | 2 < 1 < 6     |
+| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10      | =             |
+| NumDefNotNum         | number        |           | a       |                   |            |    |        |          | type "number"   | =             |
+| NumDefOptsNotNum     | number        |           | 1       | 1,a,2             |            |    |        |          | type "number"   | =             |
+|                      |               |           |         |                   |            |    |        |          |                 |               |
+| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |                 |               |
+| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error     | =             |
+| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |                 |               |
+| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option    | =             |
+| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |                 | value "d"     |
+| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error     | =             |
+|                      |               |           |         |                   |            |    |        |          |                 |               |
+| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |               |
+| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |                 |               |
+| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option    | =             |
+|                      |               |           |         |                   |            |    |        |          |                 |               |
+| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |                 |               |
+| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |                 |               |
+| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option    | =             |
+|                      |               |           |         |                   |            |    |        |          |                 |               |
+|                      | Input Vals    |           |         |                   |            |    |        |          |                 |               |
+| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |                 |               |
+| NumInsOptsNaN        | number        | 3         | 5       | a,1,2,3,4,5       | 1-3        |    |        |          | type "number"   | =             |
+| NumInsNotNum         | number        | a         |         |                   |            |    |        |          | type "number"   | =             |
+| NumInsNotNumInv      | number        | a         |         |                   | 1-3        |    |        |          | 1 < a < 3       | =             |
+| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |                 |               |
+| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |                 | 1 < 5 < 3     |
+| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3       | =             |
+| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |                 | 1 < 5 < 3     |
+| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option    | 1 < 4 < 3     |
+| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2       | 1 < 4 < 2     |
+| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option    | =             |
+| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option    | =             |
+|                      |               |           |         |                   |            |    |        |          |                 |               |
+| StrIns               | string        | c         |         |                   |            |    | c      | false    |                 |               |
+| StrInsDupeOpts       | string        | c         |         | a,b,c,c           |            |    |        |          | unique          | =             |
+| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |                 |               |
+| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |                 | default value |
+| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error     | =             |
+| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |                 | value "d"     |
+| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option    | value "d"     |
+| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error     | =             |
+| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option    | =             |
+| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option    | =             |
+| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot      | =             |
+|                      |               |           |         |                   |            |    |        |          |                 |               |
+|                      | list(string)  |           |         |                   |            |    |        |          |                 |               |
+| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |                 |               |
+| LStrInsNotList       | list(string)  | c         |         |                   |            |    |        |          | list of strings | =             |
+| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |                 |               |
+| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot    | =             |
+| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |                 |               |
+| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option    | =             |
+| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option    | =             |
+|                      |               |           |         |                   |            |    |        |          |                 |               |
+| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |                 |               |
+| MulInsNotListOpts    | multi-select  | c         | ["e"]   | c,d,e             |            |    |        |          | json encoded    | =             |
+| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option    | =             |
+| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option    | =             |
+| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot    | =             |

--- a/provider/testdata/parameter_table.md
+++ b/provider/testdata/parameter_table.md
@@ -9,8 +9,8 @@
 | EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |                 |               |
 | EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error     | =             |
 | EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10       | =             |
-| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5        | 2 < 1 < 5     |
-| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error     | =             |
+| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | valid option    | 2 < 1 < 5     |
+| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | valid option    | regex error   |
 | EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |                 |               |
 |                      |               |           |         |                   |            |    |        |          |                 |               |
 |                      | Default Set   | No inputs |         |                   |            |    |        |          |                 |               |
@@ -48,7 +48,7 @@
 | NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3       | =             |
 | NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |                 | 1 < 5 < 3     |
 | NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option    | 1 < 4 < 3     |
-| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2       | 1 < 4 < 2     |
+| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | valid option    | 1 < 4 < 2     |
 | NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option    | =             |
 | NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option    | =             |
 |                      |               |           |         |                   |            |    |        |          |                 |               |
@@ -59,7 +59,7 @@
 | StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error     | =             |
 | StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |                 | value "d"     |
 | StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option    | value "d"     |
-| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error     | =             |
+| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | valid option    | regex error   |
 | StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option    | =             |
 | StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option    | =             |
 | StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot      | =             |

--- a/provider/testdata/parameter_table.md
+++ b/provider/testdata/parameter_table.md
@@ -1,70 +1,70 @@
-| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error         |
-|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|---------------|
-|                      | Empty Vals    |           |         |                   |            |    |        |          |               |
-| Empty                | string,number |           |         |                   |            |    | ""     | false    |               |
-| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |               |
-| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |               |
-| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |               |
-| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error   |
-| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10     |
-| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5      |
-| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error   |
-| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |               |
-|                      |               |           |         |                   |            |    |        |          |               |
-|                      | Default Set   | No inputs |         |                   |            |    |        |          |               |
-| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |               |
-| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |               |
-| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0    |
-| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |               |
-| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option  |
-| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10    |
-|                      |               |           |         |                   |            |    |        |          |               |
-| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |               |
-| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error   |
-| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |               |
-| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option  |
-| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |               |
-| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error   |
-|                      |               |           |         |                   |            |    |        |          |               |
-| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |               |
-| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |               |
-| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option  |
-|                      |               |           |         |                   |            |    |        |          |               |
-| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |               |
-| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |               |
-| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option  |
-|                      |               |           |         |                   |            |    |        |          |               |
-|                      | Input Vals    |           |         |                   |            |    |        |          |               |
-| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |               |
-| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |               |
-| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |               |
-| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3     |
-| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |               |
-| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option  |
-| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2     |
-| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option  |
-| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option  |
-|                      |               |           |         |                   |            |    |        |          |               |
-| StrIns               | string        | c         |         |                   |            |    | c      | false    |               |
-| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |               |
-| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |               |
-| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error   |
-| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |               |
-| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    | c      | true     |               |
-| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error   |
-| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    | c      | true     |               |
-| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    | c      | false    |               |
-| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot    |
-|                      |               |           |         |                   |            |    |        |          |               |
-|                      | list(string)  |           |         |                   |            |    |        |          |               |
-| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |               |
-| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |               |
-| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot  |
-| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |               |
-| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    | ["c"]  | true     |               |
-| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    | ["c"]  | false    |               |
-|                      |               |           |         |                   |            |    |        |          |               |
-| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |               |
-| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    | ["c"]  | true     |               |
-| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    | ["c"]  | false    |               |
-| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot  |
+| Name                 | Type          | Input     | Default | Options           | Validation | -> | Output | Optional | Error        |
+|----------------------|---------------|-----------|---------|-------------------|------------|----|--------|----------|--------------|
+|                      | Empty Vals    |           |         |                   |            |    |        |          |              |
+| Empty                | string,number |           |         |                   |            |    | ""     | false    |              |
+| EmptyList            | list(string)  |           |         |                   |            |    | ""     | false    |              |
+| EmptyMulti           | tag-select    |           |         |                   |            |    | ""     | false    |              |
+| EmptyOpts            | string,number |           |         | 1,2,3             |            |    | ""     | false    |              |
+| EmptyRegex           | string        |           |         |                   | world      |    |        |          | regex error  |
+| EmptyMin             | number        |           |         |                   | 1-10       |    |        |          | 1 <  < 10    |
+| EmptyMinOpt          | number        |           |         | 1,2,3             | 2-5        |    |        |          | 2 <  < 5     |
+| EmptyRegexOpt        | string        |           |         | "hello","goodbye" | goodbye    |    |        |          | regex error  |
+| EmptyRegexOk         | string        |           |         |                   | .*         |    | ""     | false    |              |
+|                      |               |           |         |                   |            |    |        |          |              |
+|                      | Default Set   | No inputs |         |                   |            |    |        |          |              |
+| NumDef               | number        |           | 5       |                   |            |    | 5      | true     |              |
+| NumDefVal            | number        |           | 5       |                   | 3-7        |    | 5      | true     |              |
+| NumDefInv            | number        |           | 5       |                   | 10-        |    |        |          | 10 < 5 < 0   |
+| NumDefOpts           | number        |           | 5       | 1,3,5,7           | 2-6        |    | 5      | true     |              |
+| NumDefNotOpts        | number        |           | 5       | 1,3,7,9           | 2-6        |    |        |          | valid option |
+| NumDefInvOpt         | number        |           | 5       | 1,3,5,7           | 6-10       |    |        |          | 6 < 5 < 10   |
+|                      |               |           |         |                   |            |    |        |          |              |
+| StrDef               | string        |           | hello   |                   |            |    | hello  | true     |              |
+| StrDefInv            | string        |           | hello   |                   | world      |    |        |          | regex error  |
+| StrDefOpts           | string        |           | a       | a,b,c             |            |    | a      | true     |              |
+| StrDefNotOpts        | string        |           | a       | b,c,d             |            |    |        |          | valid option |
+| StrDefValOpts        | string        |           | a       | a,b,c,d,e,f       | [a-c]      |    | a      | true     |              |
+| StrDefInvOpt         | string        |           | d       | a,b,c,d,e,f       | [a-c]      |    |        |          | regex error  |
+|                      |               |           |         |                   |            |    |        |          |              |
+| LStrDef              | list(string)  |           | ["a"]   |                   |            |    | ["a"]  | true     |              |
+| LStrDefOpts          | list(string)  |           | ["a"]   | ["a"], ["b"]      |            |    | ["a"]  | true     |              |
+| LStrDefNotOpts       | list(string)  |           | ["a"]   | ["b"], ["c"]      |            |    |        |          | valid option |
+|                      |               |           |         |                   |            |    |        |          |              |
+| MulDef               | tag-select    |           | ["a"]   |                   |            |    | ["a"]  | true     |              |
+| MulDefOpts           | multi-select  |           | ["a"]   | a,b               |            |    | ["a"]  | true     |              |
+| MulDefNotOpts        | multi-select  |           | ["a"]   | b,c               |            |    |        |          | valid option |
+|                      |               |           |         |                   |            |    |        |          |              |
+|                      | Input Vals    |           |         |                   |            |    |        |          |              |
+| NumIns               | number        | 3         |         |                   |            |    | 3      | false    |              |
+| NumInsDef            | number        | 3         | 5       |                   |            |    | 3      | true     |              |
+| NumIns/DefInv        | number        | 3         | 5       |                   | 1-3        |    | 3      | true     |              |
+| NumIns=DefInv        | number        | 5         | 5       |                   | 1-3        |    |        |          | 1 < 5 < 3    |
+| NumInsOpts           | number        | 3         | 5       | 1,2,3,4,5         | 1-3        |    | 3      | true     |              |
+| NumInsNotOptsVal     | number        | 3         | 5       | 1,2,4,5           | 1-3        |    |        |          | valid option |
+| NumInsNotOptsInv     | number        | 3         | 5       | 1,2,4,5           | 1-2        |    |        | true     | 1 < 3 < 2    |
+| NumInsNotOpts        | number        | 3         | 5       | 1,2,4,5           |            |    |        |          | valid option |
+| NumInsNotOpts/NoDef  | number        | 3         |         | 1,2,4,5           |            |    |        |          | valid option |
+|                      |               |           |         |                   |            |    |        |          |              |
+| StrIns               | string        | c         |         |                   |            |    | c      | false    |              |
+| StrInsDef            | string        | c         | e       |                   |            |    | c      | true     |              |
+| StrIns/DefInv        | string        | c         | e       |                   | [a-c]      |    | c      | true     |              |
+| StrIns=DefInv        | string        | e         | e       |                   | [a-c]      |    |        |          | regex error  |
+| StrInsOpts           | string        | c         | e       | a,b,c,d,e         | [a-c]      |    | c      | true     |              |
+| StrInsNotOptsVal     | string        | c         | e       | a,b,d,e           | [a-c]      |    |        |          | valid option |
+| StrInsNotOptsInv     | string        | c         | e       | a,b,d,e           | [a-b]      |    |        |          | regex error  |
+| StrInsNotOpts        | string        | c         | e       | a,b,d,e           |            |    |        |          | valid option |
+| StrInsNotOpts/NoDef  | string        | c         |         | a,b,d,e           |            |    |        |          | valid option |
+| StrInsBadVal         | string        | c         |         | a,b,c,d,e         | 1-10       |    |        |          | min cannot   |
+|                      |               |           |         |                   |            |    |        |          |              |
+|                      | list(string)  |           |         |                   |            |    |        |          |              |
+| LStrIns              | list(string)  | ["c"]     |         |                   |            |    | ["c"]  | false    |              |
+| LStrInsDef           | list(string)  | ["c"]     | ["e"]   |                   |            |    | ["c"]  | true     |              |
+| LStrIns/DefInv       | list(string)  | ["c"]     | ["e"]   |                   | [a-c]      |    |        |          | regex cannot |
+| LStrInsOpts          | list(string)  | ["c"]     | ["e"]   | ["c"],["d"],["e"] |            |    | ["c"]  | true     |              |
+| LStrInsNotOpts       | list(string)  | ["c"]     | ["e"]   | ["d"],["e"]       |            |    |        |          | valid option |
+| LStrInsNotOpts/NoDef | list(string)  | ["c"]     |         | ["d"],["e"]       |            |    |        |          | valid option |
+|                      |               |           |         |                   |            |    |        |          |              |
+| MulInsOpts           | multi-select  | ["c"]     | ["e"]   | c,d,e             |            |    | ["c"]  | true     |              |
+| MulInsNotOpts        | multi-select  | ["c"]     | ["e"]   | d,e               |            |    |        |          | valid option |
+| MulInsNotOpts/NoDef  | multi-select  | ["c"]     |         | d,e               |            |    |        |          | valid option |
+| MulInsInvOpts        | multi-select  | ["c"]     | ["e"]   | c,d,e             | [a-c]      |    |        |          | regex cannot |


### PR DESCRIPTION
# What this PR does

Centralizes all validation logic into a single function on the parameter. This is intended to be imported by other packages (eg: preview) to do clientside validation before running terraform.

# Validation changes

See diff from `main`. Left side is the tests passing on `main`.
https://www.diffchecker.com/GaUlaTze/


- Input values **must** be in the option set. [Before](https://github.com/coder/terraform-provider-coder/blob/a2bb4c074b3257ac7e2fd361b7dea1cadf954206/provider/testdata/parameter_table.md?plain=1#L49) this was allowed, but enforced in `coder/coder`
- Number parameters require values to be numbers. [Before](https://github.com/coder/terraform-provider-coder/blob/a2bb4c074b3257ac7e2fd361b7dea1cadf954206/provider/testdata/parameter_table.md?plain=1#L43) this was allowed, but enforced in `coder/coder`

# Future work 

- Disallow empty values for creating workspaces: https://github.com/coder/terraform-provider-coder/blob/247df4e410c3c9ca159d59a8428975e5e873dc67/provider/parameter.go#L421-L427
- coder/coder to set the correct validation mode
- validate `monotonic` in the provider, passing in the old value via env var

[empty]: https://github.com/coder/terraform-provider-coder/blob/a2bb4c074b3257ac7e2fd361b7dea1cadf954206/provider/testdata/parameter_table.md?plain=1#L4-L14
[option]: https://github.com/coder/terraform-provider-coder/blob/a2bb4c074b3257ac7e2fd361b7dea1cadf954206/provider/testdata/parameter_table.md?plain=1#L20
[default]: https://github.com/coder/terraform-provider-coder/blob/a2bb4c074b3257ac7e2fd361b7dea1cadf954206/provider/testdata/parameter_table.md?plain=1#L46


