### PR TITLE
chore: add tag_sort option to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,3 +60,5 @@ changelog:
   use: github-native
   sort: asc
   abbrev: 0
+git:
+  tag_sort: -version:creatordate # if two tags reference the same commit, pick the latest one; see https://github.com/goreleaser/goreleaser/issues/4209


### PR DESCRIPTION
Choose more recently-created tag if multiple tags point to same ref

I published `v2.4.1` pointing to the same ref as `v2.4.1-pre0` after validating the latter. However when I published `v2.4.1`, the [action](https://github.com/coder/terraform-provider-coder/actions/runs/14965521939) chose the older tag.