### PR TITLE
feat: add expiration_policy parameter to prebuild resource

### DIFF
--- a/docs/data-sources/workspace_preset.md
+++ b/docs/data-sources/workspace_preset.md
@@ -54,11 +54,11 @@ Required:
 
 Optional:
 
-- `cache_invalidation` (Block Set, Max: 1) Configuration block that defines TTL (time-to-live) behavior for prebuilds. Use this to automatically invalidate and delete prebuilds after a certain period, ensuring they stay up-to-date. (see [below for nested schema](#nestedblock--prebuilds--cache_invalidation))
+- `expiration_policy` (Block Set, Max: 1) Configuration block that defines TTL (time-to-live) behavior for prebuilds. Use this to automatically invalidate and delete prebuilds after a certain period, ensuring they stay up-to-date. (see [below for nested schema](#nestedblock--prebuilds--expiration_policy))
 
-<a id="nestedblock--prebuilds--cache_invalidation"></a>
-### Nested Schema for `prebuilds.cache_invalidation`
+<a id="nestedblock--prebuilds--expiration_policy"></a>
+### Nested Schema for `prebuilds.expiration_policy`
 
 Required:
 
-- `invalidate_after_secs` (Number) Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.
+- `ttl` (Number) Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.

--- a/docs/data-sources/workspace_preset.md
+++ b/docs/data-sources/workspace_preset.md
@@ -51,3 +51,14 @@ data "coder_workspace_preset" "example" {
 Required:
 
 - `instances` (Number) The number of workspaces to keep in reserve for this preset.
+
+Optional:
+
+- `cache_invalidation` (Block Set, Max: 1) Configuration block that defines TTL (time-to-live) behavior for prebuilds. Use this to automatically invalidate and delete prebuilds after a certain period, ensuring they stay up-to-date. (see [below for nested schema](#nestedblock--prebuilds--cache_invalidation))
+
+<a id="nestedblock--prebuilds--cache_invalidation"></a>
+### Nested Schema for `prebuilds.cache_invalidation`
+
+Required:
+
+- `invalidate_after_secs` (Number) Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -90,11 +90,12 @@ func TestIntegration(t *testing.T) {
 				// TODO (sasswart): the cli doesn't support presets yet.
 				// once it does, the value for workspace_parameter.value
 				// will be the preset value.
-				"workspace_parameter.value":            `param value`,
-				"workspace_parameter.icon":             `param icon`,
-				"workspace_preset.name":                `preset`,
-				"workspace_preset.parameters.param":    `preset param value`,
-				"workspace_preset.prebuilds.instances": `1`,
+				"workspace_parameter.value":                                           `param value`,
+				"workspace_parameter.icon":                                            `param icon`,
+				"workspace_preset.name":                                               `preset`,
+				"workspace_preset.parameters.param":                                   `preset param value`,
+				"workspace_preset.prebuilds.instances":                                `1`,
+				"workspace_preset.prebuilds.cache_invalidation.invalidate_after_secs": `86400`,
 			},
 		},
 		{

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -90,12 +90,12 @@ func TestIntegration(t *testing.T) {
 				// TODO (sasswart): the cli doesn't support presets yet.
 				// once it does, the value for workspace_parameter.value
 				// will be the preset value.
-				"workspace_parameter.value":                                           `param value`,
-				"workspace_parameter.icon":                                            `param icon`,
-				"workspace_preset.name":                                               `preset`,
-				"workspace_preset.parameters.param":                                   `preset param value`,
-				"workspace_preset.prebuilds.instances":                                `1`,
-				"workspace_preset.prebuilds.cache_invalidation.invalidate_after_secs": `86400`,
+				"workspace_parameter.value":                        `param value`,
+				"workspace_parameter.icon":                         `param icon`,
+				"workspace_preset.name":                            `preset`,
+				"workspace_preset.parameters.param":                `preset param value`,
+				"workspace_preset.prebuilds.instances":             `1`,
+				"workspace_preset.prebuilds.expiration_policy.ttl": `86400`,
 			},
 		},
 		{

--- a/integration/test-data-source/main.tf
+++ b/integration/test-data-source/main.tf
@@ -27,6 +27,9 @@ data "coder_workspace_preset" "preset" {
 
   prebuilds {
     instances = 1
+    cache_invalidation = {
+        invalidate_after_secs = 86400
+    }
   }
 }
 
@@ -52,6 +55,7 @@ locals {
     "workspace_preset.name" : data.coder_workspace_preset.preset.name,
     "workspace_preset.parameters.param" : data.coder_workspace_preset.preset.parameters.param,
     "workspace_preset.prebuilds.instances" : tostring(one(data.coder_workspace_preset.preset.prebuilds).instances),
+    "workspace_preset.prebuilds.cache_invalidation.invalidate_after_secs" : tostring(one(data.coder_workspace_preset.preset.prebuilds.cache_invalidation).invalidate_after_secs),
   }
 }
 

--- a/integration/test-data-source/main.tf
+++ b/integration/test-data-source/main.tf
@@ -27,7 +27,7 @@ data "coder_workspace_preset" "preset" {
 
   prebuilds {
     instances = 1
-    cache_invalidation = {
+    cache_invalidation {
       invalidate_after_secs = 86400
     }
   }

--- a/integration/test-data-source/main.tf
+++ b/integration/test-data-source/main.tf
@@ -28,7 +28,7 @@ data "coder_workspace_preset" "preset" {
   prebuilds {
     instances = 1
     cache_invalidation = {
-        invalidate_after_secs = 86400
+      invalidate_after_secs = 86400
     }
   }
 }

--- a/integration/test-data-source/main.tf
+++ b/integration/test-data-source/main.tf
@@ -55,7 +55,7 @@ locals {
     "workspace_preset.name" : data.coder_workspace_preset.preset.name,
     "workspace_preset.parameters.param" : data.coder_workspace_preset.preset.parameters.param,
     "workspace_preset.prebuilds.instances" : tostring(one(data.coder_workspace_preset.preset.prebuilds).instances),
-    "workspace_preset.prebuilds.cache_invalidation.invalidate_after_secs" : tostring(one(data.coder_workspace_preset.preset.prebuilds.cache_invalidation).invalidate_after_secs),
+    "workspace_preset.prebuilds.cache_invalidation.invalidate_after_secs" : tostring(one(one(data.coder_workspace_preset.preset.prebuilds).cache_invalidation).invalidate_after_secs),
   }
 }
 

--- a/integration/test-data-source/main.tf
+++ b/integration/test-data-source/main.tf
@@ -27,8 +27,8 @@ data "coder_workspace_preset" "preset" {
 
   prebuilds {
     instances = 1
-    cache_invalidation {
-      invalidate_after_secs = 86400
+    expiration_policy {
+      ttl = 86400
     }
   }
 }
@@ -55,7 +55,7 @@ locals {
     "workspace_preset.name" : data.coder_workspace_preset.preset.name,
     "workspace_preset.parameters.param" : data.coder_workspace_preset.preset.parameters.param,
     "workspace_preset.prebuilds.instances" : tostring(one(data.coder_workspace_preset.preset.prebuilds).instances),
-    "workspace_preset.prebuilds.cache_invalidation.invalidate_after_secs" : tostring(one(one(data.coder_workspace_preset.preset.prebuilds).cache_invalidation).invalidate_after_secs),
+    "workspace_preset.prebuilds.expiration_policy.ttl" : tostring(one(one(data.coder_workspace_preset.preset.prebuilds).expiration_policy).ttl),
   }
 }
 

--- a/provider/workspace_preset.go
+++ b/provider/workspace_preset.go
@@ -94,11 +94,10 @@ func workspacePresetDataSource() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"invalidate_after_secs": {
-										Type:        schema.TypeInt,
-										Description: "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
-										Required:    true,
-										ForceNew:    true,
-										//Default:      86400, // TODO: Should we add a default value?
+										Type:         schema.TypeInt,
+										Description:  "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
+										Required:     true,
+										ForceNew:     true,
 										ValidateFunc: validation.IntAtLeast(0),
 									},
 								},

--- a/provider/workspace_preset.go
+++ b/provider/workspace_preset.go
@@ -103,7 +103,7 @@ func workspacePresetDataSource() *schema.Resource {
 										Description: "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
 										Required:    true,
 										ForceNew:    true,
-										// Ensure invalidation is between 0 and 31536000 seconds (1 year) to prevent stale prebuilds
+										// Ensure TTL is between 0 and 31536000 seconds (1 year) to prevent stale prebuilds
 										ValidateFunc: validation.IntBetween(0, 31536000),
 									},
 								},

--- a/provider/workspace_preset.go
+++ b/provider/workspace_preset.go
@@ -99,11 +99,12 @@ func workspacePresetDataSource() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"invalidate_after_secs": {
-										Type:         schema.TypeInt,
-										Description:  "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
-										Required:     true,
-										ForceNew:     true,
-										ValidateFunc: validation.IntAtLeast(0),
+										Type:        schema.TypeInt,
+										Description: "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
+										Required:    true,
+										ForceNew:    true,
+										// Ensure invalidation is between 0 and 604800 seconds (7 days) to prevent stale prebuilds
+										ValidateFunc: validation.IntBetween(0, 604800),
 									},
 								},
 							},

--- a/provider/workspace_preset.go
+++ b/provider/workspace_preset.go
@@ -22,16 +22,16 @@ type WorkspacePreset struct {
 
 type WorkspacePrebuild struct {
 	Instances int `mapstructure:"instances"`
-	// There should always be only one cache_invalidation block, but Terraform's type system
+	// There should always be only one expiration_policy block, but Terraform's type system
 	// still parses them as a slice, so we need to handle it as such. We could use
 	// an anonymous type and rd.Get to avoid a slice here, but that would not be possible
 	// for utilities that parse our terraform output using this type. To remain compatible
 	// with those cases, we use a slice here.
-	CacheInvalidation []CacheInvalidation `mapstructure:"cache_invalidation"`
+	ExpirationPolicy []ExpirationPolicy `mapstructure:"expiration_policy"`
 }
 
-type CacheInvalidation struct {
-	InvalidateAfterSecs int `mapstructure:"invalidate_after_secs"`
+type ExpirationPolicy struct {
+	TTL int `mapstructure:"ttl"`
 }
 
 func workspacePresetDataSource() *schema.Resource {
@@ -91,20 +91,20 @@ func workspacePresetDataSource() *schema.Resource {
 							ForceNew:     true,
 							ValidateFunc: validation.IntAtLeast(0),
 						},
-						"cache_invalidation": {
+						"expiration_policy": {
 							Type:        schema.TypeSet,
 							Description: "Configuration block that defines TTL (time-to-live) behavior for prebuilds. Use this to automatically invalidate and delete prebuilds after a certain period, ensuring they stay up-to-date.",
 							Optional:    true,
 							MaxItems:    1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"invalidate_after_secs": {
+									"ttl": {
 										Type:        schema.TypeInt,
 										Description: "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
 										Required:    true,
 										ForceNew:    true,
-										// Ensure invalidation is between 0 and 604800 seconds (7 days) to prevent stale prebuilds
-										ValidateFunc: validation.IntBetween(0, 604800),
+										// Ensure invalidation is between 0 and 31536000 seconds (1 year) to prevent stale prebuilds
+										ValidateFunc: validation.IntBetween(0, 31536000),
 									},
 								},
 							},

--- a/provider/workspace_preset.go
+++ b/provider/workspace_preset.go
@@ -21,7 +21,12 @@ type WorkspacePreset struct {
 }
 
 type WorkspacePrebuild struct {
-	Instances int `mapstructure:"instances"`
+	Instances         int                 `mapstructure:"instances"`
+	CacheInvalidation []CacheInvalidation `mapstructure:"cache_invalidation"`
+}
+
+type CacheInvalidation struct {
+	InvalidateAfterSecs int `mapstructure:"invalidate_after_secs"`
 }
 
 func workspacePresetDataSource() *schema.Resource {
@@ -80,6 +85,24 @@ func workspacePresetDataSource() *schema.Resource {
 							Required:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.IntAtLeast(0),
+						},
+						"cache_invalidation": {
+							Type:        schema.TypeSet,
+							Description: "Configuration block that defines TTL (time-to-live) behavior for prebuilds. Use this to automatically invalidate and delete prebuilds after a certain period, ensuring they stay up-to-date.",
+							Optional:    true,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"invalidate_after_secs": {
+										Type:        schema.TypeInt,
+										Description: "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
+										Required:    true,
+										ForceNew:    true,
+										//Default:      86400, // TODO: Should we add a default value?
+										ValidateFunc: validation.IntAtLeast(0),
+									},
+								},
+							},
 						},
 					},
 				},

--- a/provider/workspace_preset.go
+++ b/provider/workspace_preset.go
@@ -21,7 +21,12 @@ type WorkspacePreset struct {
 }
 
 type WorkspacePrebuild struct {
-	Instances         int                 `mapstructure:"instances"`
+	Instances int `mapstructure:"instances"`
+	// There should always be only one cache_invalidation block, but Terraform's type system
+	// still parses them as a slice, so we need to handle it as such. We could use
+	// an anonymous type and rd.Get to avoid a slice here, but that would not be possible
+	// for utilities that parse our terraform output using this type. To remain compatible
+	// with those cases, we use a slice here.
 	CacheInvalidation []CacheInvalidation `mapstructure:"cache_invalidation"`
 }
 

--- a/provider/workspace_preset_test.go
+++ b/provider/workspace_preset_test.go
@@ -157,6 +157,9 @@ func TestWorkspacePreset(t *testing.T) {
 					cache_invalidation {}
 				}
 			}`,
+			// Note: Match only the beginning of the error message to make the test more reliable.
+			// The full error message includes formatting differences like newlines, which could
+			// cause the test to fail unnecessarily.
 			ExpectError: regexp.MustCompile("The argument \"invalidate_after_secs\" is required,"),
 		},
 		{
@@ -209,7 +212,7 @@ func TestWorkspacePreset(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.Name, func(t *testing.T) {
 			t.Parallel()
-			
+
 			resource.Test(t, resource.TestCase{
 				ProviderFactories: coderFactory(),
 				IsUnitTest:        true,

--- a/provider/workspace_preset_test.go
+++ b/provider/workspace_preset_test.go
@@ -190,6 +190,23 @@ func TestWorkspacePreset(t *testing.T) {
 			},
 		},
 		{
+			Name: "Prebuilds block with cache_invalidation.invalidate_after_secs set to 15 days (exceeds 7 days limit)",
+			Config: `
+			data "coder_workspace_preset" "preset_1" {
+				name = "preset_1"
+				parameters = {
+					"region" = "us-east1-a"
+				}
+				prebuilds {
+					instances = 1
+					cache_invalidation {
+						invalidate_after_secs = 1296000
+					}
+				}
+			}`,
+			ExpectError: regexp.MustCompile(`expected prebuilds.0.cache_invalidation.0.invalidate_after_secs to be in the range \(0 - 604800\), got 1296000`),
+		},
+		{
 			Name: "Prebuilds is set with a cache_invalidation field with its required fields and an unexpected argument",
 			Config: `
 			data "coder_workspace_preset" "preset_1" {

--- a/provider/workspace_preset_test.go
+++ b/provider/workspace_preset_test.go
@@ -1,7 +1,6 @@
 package provider_test
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -210,8 +209,7 @@ func TestWorkspacePreset(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.Name, func(t *testing.T) {
 			t.Parallel()
-
-			fmt.Println("testcase.ExpectError: ", testcase.ExpectError)
+			
 			resource.Test(t, resource.TestCase{
 				ProviderFactories: coderFactory(),
 				IsUnitTest:        true,

--- a/provider/workspace_preset_test.go
+++ b/provider/workspace_preset_test.go
@@ -1,6 +1,7 @@
 package provider_test
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -157,7 +158,7 @@ func TestWorkspacePreset(t *testing.T) {
 					cache_invalidation {}
 				}
 			}`,
-			ExpectError: regexp.MustCompile("The argument \"invalidate_after_secs\" is required, but no definition was found."),
+			ExpectError: regexp.MustCompile("The argument \"invalidate_after_secs\" is required,"),
 		},
 		{
 			Name: "Prebuilds is set with a cache_invalidation field with its required fields",
@@ -210,6 +211,7 @@ func TestWorkspacePreset(t *testing.T) {
 		t.Run(testcase.Name, func(t *testing.T) {
 			t.Parallel()
 
+			fmt.Println("testcase.ExpectError: ", testcase.ExpectError)
 			resource.Test(t, resource.TestCase{
 				ProviderFactories: coderFactory(),
 				IsUnitTest:        true,

--- a/provider/workspace_preset_test.go
+++ b/provider/workspace_preset_test.go
@@ -145,7 +145,7 @@ func TestWorkspacePreset(t *testing.T) {
 			},
 		},
 		{
-			Name: "Prebuilds is set with a cache_invalidation field without its required fields",
+			Name: "Prebuilds is set with a expiration_policy field without its required fields",
 			Config: `
 			data "coder_workspace_preset" "preset_1" {
 				name = "preset_1"
@@ -154,16 +154,13 @@ func TestWorkspacePreset(t *testing.T) {
 				}
 				prebuilds {
 					instances = 1
-					cache_invalidation {}
+					expiration_policy {}
 				}
 			}`,
-			// Note: Match only the beginning of the error message to make the test more reliable.
-			// The full error message includes formatting differences like newlines, which could
-			// cause the test to fail unnecessarily.
-			ExpectError: regexp.MustCompile("The argument \"invalidate_after_secs\" is required,"),
+			ExpectError: regexp.MustCompile("The argument \"ttl\" is required, but no definition was found."),
 		},
 		{
-			Name: "Prebuilds is set with a cache_invalidation field with its required fields",
+			Name: "Prebuilds is set with a expiration_policy field with its required fields",
 			Config: `
 			data "coder_workspace_preset" "preset_1" {
 				name = "preset_1"
@@ -172,8 +169,8 @@ func TestWorkspacePreset(t *testing.T) {
 				}
 				prebuilds {
 					instances = 1
-					cache_invalidation {
-						invalidate_after_secs = 86400
+					expiration_policy {
+						ttl = 86400
 					}
 				}
 			}`,
@@ -185,12 +182,12 @@ func TestWorkspacePreset(t *testing.T) {
 				require.NotNil(t, resource)
 				attrs := resource.Primary.Attributes
 				require.Equal(t, attrs["name"], "preset_1")
-				require.Equal(t, attrs["prebuilds.0.cache_invalidation.0.invalidate_after_secs"], "86400")
+				require.Equal(t, attrs["prebuilds.0.expiration_policy.0.ttl"], "86400")
 				return nil
 			},
 		},
 		{
-			Name: "Prebuilds block with cache_invalidation.invalidate_after_secs set to 15 days (exceeds 7 days limit)",
+			Name: "Prebuilds block with expiration_policy.ttl set to 2 years (exceeds 1 year limit)",
 			Config: `
 			data "coder_workspace_preset" "preset_1" {
 				name = "preset_1"
@@ -199,15 +196,15 @@ func TestWorkspacePreset(t *testing.T) {
 				}
 				prebuilds {
 					instances = 1
-					cache_invalidation {
-						invalidate_after_secs = 1296000
+					expiration_policy {
+						ttl = 63072000
 					}
 				}
 			}`,
-			ExpectError: regexp.MustCompile(`expected prebuilds.0.cache_invalidation.0.invalidate_after_secs to be in the range \(0 - 604800\), got 1296000`),
+			ExpectError: regexp.MustCompile(`expected prebuilds.0.expiration_policy.0.ttl to be in the range \(0 - 31536000\), got 63072000`),
 		},
 		{
-			Name: "Prebuilds is set with a cache_invalidation field with its required fields and an unexpected argument",
+			Name: "Prebuilds is set with a expiration_policy field with its required fields and an unexpected argument",
 			Config: `
 			data "coder_workspace_preset" "preset_1" {
 				name = "preset_1"
@@ -216,8 +213,8 @@ func TestWorkspacePreset(t *testing.T) {
 				}
 				prebuilds {
 					instances = 1
-					cache_invalidation {
-						invalidate_after_secs = 86400
+					expiration_policy {
+						ttl = 86400
 						invalid_argument = "test"
 					}
 				}


### PR DESCRIPTION
## Summary

This PR adds Terraform support for configuring a `expiration_policy` field in a template preset. This allows users to specify a TTL (`ttl`) for prebuild workspaces, after which they are considered expired and eligible for deletion and replacement.

## Changes

* Updated the Terraform template preset resource to include the new `expiration_policy` block.
* Added validation and tests to ensure correct TTL handling.

## Example Usage

```
prebuilds = {
	  instances = 2
	  expiration_policy {
		  ttl = 86400
	  }
  }
```

Related:
* Required for https://github.com/coder/coder/pull/17996
* Related to https://github.com/coder/coder/issues/17916

