### PR TITLE
chore: add minimum TTL value for expiration.policy.ttl

### DIFF
--- a/provider/workspace_preset.go
+++ b/provider/workspace_preset.go
@@ -103,8 +103,8 @@ func workspacePresetDataSource() *schema.Resource {
 										Description: "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
 										Required:    true,
 										ForceNew:    true,
-										// Ensure TTL is between 0 and 31536000 seconds (1 year) to prevent stale prebuilds
-										ValidateFunc: validation.IntBetween(0, 31536000),
+										// Ensure TTL is between 3600 seconds (1 hour) and 31536000 seconds (1 year)
+										ValidateFunc: validation.IntBetween(3600, 31536000),
 									},
 								},
 							},

--- a/provider/workspace_preset.go
+++ b/provider/workspace_preset.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -103,8 +104,17 @@ func workspacePresetDataSource() *schema.Resource {
 										Description: "Time in seconds after which an unclaimed prebuild is considered expired and eligible for cleanup.",
 										Required:    true,
 										ForceNew:    true,
-										// Ensure TTL is between 3600 seconds (1 hour) and 31536000 seconds (1 year)
-										ValidateFunc: validation.IntBetween(3600, 31536000),
+										// Ensure TTL is either 0 (to disable expiration) or between 3600 seconds (1 hour) and 31536000 seconds (1 year)
+										ValidateFunc: func(val interface{}, key string) ([]string, []error) {
+											v := val.(int)
+											if v == 0 {
+												return nil, nil
+											}
+											if v < 3600 || v > 31536000 {
+												return nil, []error{fmt.Errorf("%q must be 0 or between 3600 and 31536000, got %d", key, v)}
+											}
+											return nil, nil
+										},
 									},
 								},
 							},

--- a/provider/workspace_preset_test.go
+++ b/provider/workspace_preset_test.go
@@ -187,6 +187,23 @@ func TestWorkspacePreset(t *testing.T) {
 			},
 		},
 		{
+			Name: "Prebuilds block with expiration_policy.ttl set to 30 minutes (below 1 hour limit)",
+			Config: `
+			data "coder_workspace_preset" "preset_1" {
+				name = "preset_1"
+				parameters = {
+					"region" = "us-east1-a"
+				}
+				prebuilds {
+					instances = 1
+					expiration_policy {
+						ttl = 1800
+					}
+				}
+			}`,
+			ExpectError: regexp.MustCompile(`expected prebuilds.0.expiration_policy.0.ttl to be in the range \(3600 - 31536000\), got 1800`),
+		},
+		{
 			Name: "Prebuilds block with expiration_policy.ttl set to 2 years (exceeds 1 year limit)",
 			Config: `
 			data "coder_workspace_preset" "preset_1" {
@@ -201,7 +218,7 @@ func TestWorkspacePreset(t *testing.T) {
 					}
 				}
 			}`,
-			ExpectError: regexp.MustCompile(`expected prebuilds.0.expiration_policy.0.ttl to be in the range \(0 - 31536000\), got 63072000`),
+			ExpectError: regexp.MustCompile(`expected prebuilds.0.expiration_policy.0.ttl to be in the range \(3600 - 31536000\), got 63072000`),
 		},
 		{
 			Name: "Prebuilds is set with a expiration_policy field with its required fields and an unexpected argument",


### PR DESCRIPTION
## Summary

This PR improves validation for the `expiration_policy.ttl` field in the Terraform schema by allowing an explicit value of `0` to disable expiration, while also enforcing a valid range of 3600 seconds (1 hour) to 31536000 seconds (1 year) for all other values. This ensures that prebuild TTLs are not configured with values that are too short, which could lead to premature expiration and unnecessary prebuild churn.

## Changes

* Replaced validation.IntBetween with a custom validation function.
* TTL is now allowed to be:
  * `0` disables expiration
  * Between `3600` and `31536000` to enforce TTL values between 1 hour and 1 year.

No functional changes beyond input validation.

Related to: https://github.com/coder/terraform-provider-coder/pull/404