### PR TITLE
fix: typo in data coder_external_auth example and docs

### DIFF
--- a/docs/data-sources/external_auth.md
+++ b/docs/data-sources/external_auth.md
@@ -21,7 +21,7 @@ data "coder_external_auth" "github" {
 }
 
 data "coder_external_auth" "azure-identity" {
-  id       = "azure-identiy"
+  id       = "azure-identity"
   optional = true
 }
 ```

--- a/examples/data-sources/coder_external_auth/data-source.tf
+++ b/examples/data-sources/coder_external_auth/data-source.tf
@@ -6,6 +6,6 @@ data "coder_external_auth" "github" {
 }
 
 data "coder_external_auth" "azure-identity" {
-  id       = "azure-identiy"
+  id       = "azure-identity"
   optional = true
 }


### PR DESCRIPTION
Also present in https://registry.terraform.io/providers/coder/coder/latest/docs/data-sources/external_auth