### PR TITLE
fix: correct URL validation and centralize logic

### DIFF
--- a/provider/app.go
+++ b/provider/app.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"net/url"
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 	"regexp"
 
 	"github.com/google/uuid"
@@ -93,15 +93,9 @@ func appResource() *schema.Resource {
 				Description: "A URL to an icon that will display in the dashboard. View built-in " +
 					"icons [here](https://github.com/coder/coder/tree/main/site/static/icon). Use a " +
 					"built-in icon with `\"${data.coder_workspace.me.access_url}/icon/<path>\"`.",
-				ForceNew: true,
-				Optional: true,
-				ValidateFunc: func(i any, s string) ([]string, []error) {
-					_, err := url.Parse(s)
-					if err != nil {
-						return nil, []error{err}
-					}
-					return nil, nil
-				},
+				ForceNew:     true,
+				Optional:     true,
+				ValidateFunc: helpers.ValidateURL,
 			},
 			"slug": {
 				Type: schema.TypeString,

--- a/provider/app.go
+++ b/provider/app.go
@@ -2,13 +2,14 @@ package provider
 
 import (
 	"context"
-	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 	"regexp"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 )
 
 var (

--- a/provider/helpers/validation.go
+++ b/provider/helpers/validation.go
@@ -5,15 +5,18 @@ import (
 	"net/url"
 )
 
-// ValidateURL checks that the given value is a valid URL string.
+// ValidateURL validates that value is a valid URL string.
+// Accepts empty strings, local file paths, file:// URLs, and http/https URLs.
 // Example: for `icon = "/icon/region.svg"`, value is `/icon/region.svg` and label is `icon`.
-func ValidateURL(value interface{}, label string) ([]string, []error) {
+func ValidateURL(value any, label string) ([]string, []error) {
 	val, ok := value.(string)
 	if !ok {
 		return nil, []error{fmt.Errorf("expected %q to be a string", label)}
 	}
+
 	if _, err := url.Parse(val); err != nil {
 		return nil, []error{err}
 	}
+	
 	return nil, nil
 }

--- a/provider/helpers/validation.go
+++ b/provider/helpers/validation.go
@@ -1,0 +1,19 @@
+package helpers
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ValidateURL checks that the given value is a valid URL string.
+// Example: for `icon = "/icon/region.svg"`, value is `/icon/region.svg` and label is `icon`.
+func ValidateURL(value interface{}, label string) ([]string, []error) {
+	val, ok := value.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected %q to be a string", label)}
+	}
+	if _, err := url.Parse(val); err != nil {
+		return nil, []error{err}
+	}
+	return nil, nil
+}

--- a/provider/helpers/validation_test.go
+++ b/provider/helpers/validation_test.go
@@ -1,8 +1,9 @@
 package helpers
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateURL(t *testing.T) {
@@ -137,27 +138,17 @@ func TestValidateURL(t *testing.T) {
 			warnings, errors := ValidateURL(tt.value, tt.label)
 
 			if tt.expectError {
-				if len(errors) == 0 {
-					t.Errorf("expected an error but got none")
-					return
-				}
+				require.NotEmpty(t, errors, "expected an error but got none")
 
 				if tt.errorContains != "" {
-					errorStr := errors[0].Error()
-					if !strings.Contains(errorStr, tt.errorContains) {
-						t.Errorf("expected error to contain %q, got %q", tt.errorContains, errorStr)
-					}
+					require.Contains(t, errors[0].Error(), tt.errorContains)
 				}
 			} else {
-				if len(errors) > 0 {
-					t.Errorf("expected no errors but got: %v", errors)
-				}
-
-				// Should always return nil for warnings
-				if warnings != nil {
-					t.Errorf("expected warnings to be nil, got %v", warnings)
-				}
+				require.Empty(t, errors, "expected no errors but got: %v", errors)
 			}
+
+			// Should always return nil for warnings
+			require.Nil(t, warnings, "expected warnings to be nil, got %v", warnings)
 		})
 	}
 }

--- a/provider/helpers/validation_test.go
+++ b/provider/helpers/validation_test.go
@@ -138,17 +138,14 @@ func TestValidateURL(t *testing.T) {
 			warnings, errors := ValidateURL(tt.value, tt.label)
 
 			if tt.expectError {
-				require.NotEmpty(t, errors, "expected an error but got none")
-
-				if tt.errorContains != "" {
-					require.Contains(t, errors[0].Error(), tt.errorContains)
-				}
+				require.Len(t, errors, 1, "expected an error but got none")
+				require.Contains(t, errors[0].Error(), tt.errorContains)
 			} else {
 				require.Empty(t, errors, "expected no errors but got: %v", errors)
 			}
 
 			// Should always return nil for warnings
-			require.Nil(t, warnings, "expected warnings to be nil, got %v", warnings)
+			require.Nil(t, warnings, "expected warnings to be nil but got: %v", warnings)
 		})
 	}
 }

--- a/provider/helpers/validation_test.go
+++ b/provider/helpers/validation_test.go
@@ -1,0 +1,163 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         any
+		label         string
+		expectError   bool
+		errorContains string
+	}{
+		// Valid cases
+		{
+			name:        "empty string",
+			value:       "",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "valid http URL",
+			value:       "http://example.com",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "valid https URL",
+			value:       "https://example.com/path",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "absolute file path",
+			value:       "/path/to/file",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "relative file path",
+			value:       "./file.txt",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "relative path up directory",
+			value:       "../config.json",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "simple filename",
+			value:       "file.txt",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "URL with query params",
+			value:       "https://example.com/search?q=test",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "URL with fragment",
+			value:       "https://example.com/page#section",
+			label:       "url",
+			expectError: false,
+		},
+
+		// Various URL schemes that url.Parse accepts
+		{
+			name:        "file URL scheme",
+			value:       "file:///path/to/file",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "ftp scheme",
+			value:       "ftp://files.example.com/file.txt",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "mailto scheme",
+			value:       "mailto:user@example.com",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "tel scheme",
+			value:       "tel:+1234567890",
+			label:       "url",
+			expectError: false,
+		},
+		{
+			name:        "data scheme",
+			value:       "data:text/plain;base64,SGVsbG8=",
+			label:       "url",
+			expectError: false,
+		},
+
+		// Invalid cases
+		{
+			name:          "non-string type - int",
+			value:         123,
+			label:         "url",
+			expectError:   true,
+			errorContains: "expected \"url\" to be a string",
+		},
+		{
+			name:          "non-string type - nil",
+			value:         nil,
+			label:         "config_url",
+			expectError:   true,
+			errorContains: "expected \"config_url\" to be a string",
+		},
+		{
+			name:          "invalid URL with spaces",
+			value:         "http://example .com",
+			label:         "url",
+			expectError:   true,
+			errorContains: "invalid character",
+		},
+		{
+			name:          "malformed URL",
+			value:         "http://[::1:80",
+			label:         "endpoint",
+			expectError:   true,
+			errorContains: "missing ']'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings, errors := ValidateURL(tt.value, tt.label)
+
+			if tt.expectError {
+				if len(errors) == 0 {
+					t.Errorf("expected an error but got none")
+					return
+				}
+
+				if tt.errorContains != "" {
+					errorStr := errors[0].Error()
+					if !strings.Contains(errorStr, tt.errorContains) {
+						t.Errorf("expected error to contain %q, got %q", tt.errorContains, errorStr)
+					}
+				}
+			} else {
+				if len(errors) > 0 {
+					t.Errorf("expected no errors but got: %v", errors)
+				}
+
+				// Should always return nil for warnings
+				if warnings != nil {
+					t.Errorf("expected warnings to be nil, got %v", warnings)
+				}
+			}
+		})
+	}
+}

--- a/provider/metadata.go
+++ b/provider/metadata.go
@@ -2,11 +2,13 @@ package provider
 
 import (
 	"context"
-	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 )
 
 func metadataResource() *schema.Resource {

--- a/provider/metadata.go
+++ b/provider/metadata.go
@@ -2,8 +2,7 @@ package provider
 
 import (
 	"context"
-	"net/url"
-
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -56,15 +55,9 @@ func metadataResource() *schema.Resource {
 				Description: "A URL to an icon that will display in the dashboard. View built-in " +
 					"icons [here](https://github.com/coder/coder/tree/main/site/static/icon). Use a " +
 					"built-in icon with `\"${data.coder_workspace.me.access_url}/icon/<path>\"`.",
-				ForceNew: true,
-				Optional: true,
-				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
-					_, err := url.Parse(s)
-					if err != nil {
-						return nil, []error{err}
-					}
-					return nil, nil
-				},
+				ForceNew:     true,
+				Optional:     true,
+				ValidateFunc: helpers.ValidateURL,
 			},
 			"daily_cost": {
 				Type: schema.TypeInt,

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"net/url"
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 	"os"
 	"regexp"
 	"strconv"
@@ -223,15 +223,9 @@ func parameterDataSource() *schema.Resource {
 				Description: "A URL to an icon that will display in the dashboard. View built-in " +
 					"icons [here](https://github.com/coder/coder/tree/main/site/static/icon). Use a " +
 					"built-in icon with `\"${data.coder_workspace.me.access_url}/icon/<path>\"`.",
-				ForceNew: true,
-				Optional: true,
-				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
-					_, err := url.Parse(s)
-					if err != nil {
-						return nil, []error{err}
-					}
-					return nil, nil
-				},
+				ForceNew:     true,
+				Optional:     true,
+				ValidateFunc: helpers.ValidateURL,
 			},
 			"option": {
 				Type:        schema.TypeList,
@@ -263,15 +257,9 @@ func parameterDataSource() *schema.Resource {
 							Description: "A URL to an icon that will display in the dashboard. View built-in " +
 								"icons [here](https://github.com/coder/coder/tree/main/site/static/icon). Use a " +
 								"built-in icon with `\"${data.coder_workspace.me.access_url}/icon/<path>\"`.",
-							ForceNew: true,
-							Optional: true,
-							ValidateFunc: func(i interface{}, s string) ([]string, []error) {
-								_, err := url.Parse(s)
-								if err != nil {
-									return nil, []error{err}
-								}
-								return nil, nil
-							},
+							ForceNew:     true,
+							Optional:     true,
+							ValidateFunc: helpers.ValidateURL,
 						},
 					},
 				},

--- a/provider/parameter.go
+++ b/provider/parameter.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 	"os"
 	"regexp"
 	"strconv"
@@ -19,6 +18,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/mitchellh/mapstructure"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 )
 
 var (

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -227,23 +227,19 @@ func TestParameter(t *testing.T) {
 			data "coder_parameter" "region" {
 				name = "Region"
 				type = "string"
-				default = "2"
+				default = "1"
 				option {
 					name = "1"
 					value = "1"
 					icon = "/icon/code.svg"
 					description = "Something!"
 				}
-				option {
-					name = "2"
-					value = "2"
-				}
 			}
 			`,
 		Check: func(state *terraform.ResourceState) {
 			for key, expected := range map[string]string{
 				"name":                 "Region",
-				"option.#":             "2",
+				"option.#":             "1",
 				"option.0.name":        "1",
 				"option.0.value":       "1",
 				"option.0.icon":        "/icon/code.svg",
@@ -665,7 +661,33 @@ data "coder_parameter" "region" {
 			}
 			`,
 		ExpectError: regexp.MustCompile("ephemeral parameter requires the default property"),
-	}} {
+	}, {
+		Name: "InvalidIconURL",
+		Config: `
+			data "coder_parameter" "region" {
+				name = "Region"
+				type = "string"
+				icon = "/icon%.svg"
+			}
+			`,
+		ExpectError: regexp.MustCompile("invalid URL escape"),
+	}, {
+		Name: "OptionInvalidIconURL",
+		Config: `
+			data "coder_parameter" "region" {
+				name = "Region"
+				type = "string"
+				option {
+					name = "1"
+					value = "1"
+					icon = "/icon%.svg"
+					description = "Something!"
+				}
+			}
+			`,
+		ExpectError: regexp.MustCompile("invalid URL escape"),
+	},
+	} {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()

--- a/provider/parameter_test.go
+++ b/provider/parameter_test.go
@@ -227,19 +227,23 @@ func TestParameter(t *testing.T) {
 			data "coder_parameter" "region" {
 				name = "Region"
 				type = "string"
-				default = "1"
+				default = "2"
 				option {
 					name = "1"
 					value = "1"
 					icon = "/icon/code.svg"
 					description = "Something!"
 				}
+				option {
+					name = "2"
+					value = "2"
+				}
 			}
 			`,
 		Check: func(state *terraform.ResourceState) {
 			for key, expected := range map[string]string{
 				"name":                 "Region",
-				"option.#":             "1",
+				"option.#":             "2",
 				"option.0.name":        "1",
 				"option.0.value":       "1",
 				"option.0.icon":        "/icon/code.svg",

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 	"net/url"
 	"reflect"
 	"strings"
@@ -26,14 +27,8 @@ func New() *schema.Provider {
 				Optional:    true,
 				// The "CODER_AGENT_URL" environment variable is used by default
 				// as the Access URL when generating scripts.
-				DefaultFunc: schema.EnvDefaultFunc("CODER_AGENT_URL", "https://mydeployment.coder.com"),
-				ValidateFunc: func(i interface{}, s string) ([]string, []error) {
-					_, err := url.Parse(s)
-					if err != nil {
-						return nil, []error{err}
-					}
-					return nil, nil
-				},
+				DefaultFunc:  schema.EnvDefaultFunc("CODER_AGENT_URL", "https://mydeployment.coder.com"),
+				ValidateFunc: helpers.ValidateURL,
 			},
 		},
 		ConfigureContextFunc: func(c context.Context, resourceData *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 	"net/url"
 	"reflect"
 	"strings"
@@ -11,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"golang.org/x/xerrors"
+
+	"github.com/coder/terraform-provider-coder/v2/provider/helpers"
 )
 
 type config struct {


### PR DESCRIPTION
### Description

Fixes incorrect URL validation logic previously used in URL definitions, where the attribute label (`s`) was being parsed instead of the actual value. This bug caused invalid URLs to be silently accepted.

Additionally, this PR introduces a shared `ValidateURL` helper function to remove duplication and ensure consistent behavior across all URL fields.

### Changes

- Fixed incorrect use of `url.Parse(s)`, now validating the actual value.
- Added `ValidateURL` helper function for consistent and reusable validation.
- Updated all schema definitions that perform URL validation to use `ValidateURL`.
- Adjusted tests to match the corrected validation logic.