### PR TITLE
feat: add tooltip field to workspace app

### DIFF
--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -31,6 +31,7 @@ resource "coder_app" "code-server" {
   display_name = "VS Code"
   icon         = "${data.coder_workspace.me.access_url}/icon/code.svg"
   url          = "http://localhost:13337"
+  tooltip      = "You need to [Install Coder Desktop](https://coder.com/docs/user-guides/desktop#install-coder-desktop) to use this button."
   share        = "owner"
   subdomain    = false
   open_in      = "window"

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -72,7 +72,7 @@ resource "coder_app" "vim" {
 - `order` (Number) The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order).
 - `share` (String) Determines the level which the application is shared at. Valid levels are `"owner"` (default), `"authenticated"` and `"public"`. Level `"owner"` disables sharing on the app, so only the workspace owner can access it. Level `"authenticated"` shares the app with all authenticated users. Level `"public"` shares it with any user, including unauthenticated users. Permitted application sharing levels can be configured site-wide via a flag on `coder server` (Enterprise only).
 - `subdomain` (Boolean) Determines whether the app will be accessed via it's own subdomain or whether it will be accessed via a path on Coder. If wildcards have not been setup by the administrator then apps with `subdomain` set to `true` will not be accessible. Defaults to `false`.
-- `tooltip` (String) String with markdown support to display over the app icon in a workspace dashboard.
+- `tooltip` (String) Markdown text that is displayed when hovering over workspace apps.
 - `url` (String) An external url if `external=true` or a URL to be proxied to from inside the workspace. This should be of the form `http://localhost:PORT[/SUBPATH]`. Either `command` or `url` may be specified, but not both.
 
 ### Read-Only

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -71,6 +71,7 @@ resource "coder_app" "vim" {
 - `order` (Number) The order determines the position of app in the UI presentation. The lowest order is shown first and apps with equal order are sorted by name (ascending order).
 - `share` (String) Determines the level which the application is shared at. Valid levels are `"owner"` (default), `"authenticated"` and `"public"`. Level `"owner"` disables sharing on the app, so only the workspace owner can access it. Level `"authenticated"` shares the app with all authenticated users. Level `"public"` shares it with any user, including unauthenticated users. Permitted application sharing levels can be configured site-wide via a flag on `coder server` (Enterprise only).
 - `subdomain` (Boolean) Determines whether the app will be accessed via it's own subdomain or whether it will be accessed via a path on Coder. If wildcards have not been setup by the administrator then apps with `subdomain` set to `true` will not be accessible. Defaults to `false`.
+- `tooltip` (String) String with markdown support to display over the app icon in a workspace dashboard.
 - `url` (String) An external url if `external=true` or a URL to be proxied to from inside the workspace. This should be of the form `http://localhost:PORT[/SUBPATH]`. Either `command` or `url` may be specified, but not both.
 
 ### Read-Only

--- a/examples/resources/coder_app/resource.tf
+++ b/examples/resources/coder_app/resource.tf
@@ -16,6 +16,7 @@ resource "coder_app" "code-server" {
   display_name = "VS Code"
   icon         = "${data.coder_workspace.me.access_url}/icon/code.svg"
   url          = "http://localhost:13337"
+  tooltip      = "You need to [Install Coder Desktop](https://coder.com/docs/user-guides/desktop#install-coder-desktop) to use this button."
   share        = "owner"
   subdomain    = false
   open_in      = "window"

--- a/provider/app.go
+++ b/provider/app.go
@@ -27,7 +27,7 @@ var (
 const (
 	appDisplayNameMaxLength = 64 // database column limit
 	appGroupNameMaxLength   = 64
-	appTooltipMaxLength     = 512
+	appTooltipMaxLength     = 2048
 )
 
 func appResource() *schema.Resource {
@@ -276,7 +276,7 @@ func appResource() *schema.Resource {
 			},
 			"tooltip": {
 				Type:        schema.TypeString,
-				Description: "String with markdown support to display over the app icon in a workspace dashboard.",
+				Description: "Markdown text that is displayed when hovering over workspace apps.",
 				ForceNew:    true,
 				Optional:    true,
 				ValidateDiagFunc: func(val any, c cty.Path) diag.Diagnostics {

--- a/provider/app.go
+++ b/provider/app.go
@@ -27,6 +27,7 @@ var (
 const (
 	appDisplayNameMaxLength = 64 // database column limit
 	appGroupNameMaxLength   = 64
+	appTooltipMaxLength     = 512
 )
 
 func appResource() *schema.Resource {
@@ -271,6 +272,23 @@ func appResource() *schema.Resource {
 					}
 
 					return diag.Errorf(`invalid "coder_app" open_in value, must be one of "tab", "slim-window": %q`, valStr)
+				},
+			},
+			"tooltip": {
+				Type:        schema.TypeString,
+				Description: "String with markdown support to display over the app icon in a workspace dashboard.",
+				ForceNew:    true,
+				Optional:    true,
+				ValidateDiagFunc: func(val any, c cty.Path) diag.Diagnostics {
+					valStr, ok := val.(string)
+					if !ok {
+						return diag.Errorf("expected string, got %T", val)
+					}
+
+					if len(valStr) > appTooltipMaxLength {
+						return diag.Errorf("tooltip is too long (max %d characters)", appTooltipMaxLength)
+					}
+					return nil
 				},
 			},
 		},

--- a/provider/app_test.go
+++ b/provider/app_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -556,13 +557,8 @@ func TestApp(t *testing.T) {
 					"#install-coder-desktop) to use this button.",
 			},
 			{
-				name: "TooltipTooLong", // > 512 characters
-				tooltip: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
-					"incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud " +
-					"exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor " +
-					"in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint " +
-					"occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. " +
-					"Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque.",
+				name:        "TooltipTooLong",
+				tooltip:     strings.Repeat("a", 2049),
 				expectError: regexp.MustCompile("tooltip is too long"),
 			},
 		}

--- a/provider/app_test.go
+++ b/provider/app_test.go
@@ -556,15 +556,6 @@ func TestApp(t *testing.T) {
 					"#install-coder-desktop) to use this button.",
 			},
 			{
-				name: "TooltipMaxLength", // < 512 characters
-				tooltip: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut" +
-					"labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco" +
-					"laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in" +
-					"voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat" +
-					"non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Sed ut" +
-					"perspiciatis unde omnis iste natus error sit voluptatem accusant",
-			},
-			{
 				name: "TooltipTooLong", // > 512 characters
 				tooltip: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
 					"incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud " +


### PR DESCRIPTION
## Summary

In this pull request we're adding an optional `tooltip` field. The `tooltip` field is a string field (with markdown support) that will be used to display tooltips on hover over app buttons in a workspace dashboard.

Tooltip screenshot

<img width="816" height="275" alt="Screenshot 2025-08-29 at 4 11 56 PM" src="https://github.com/user-attachments/assets/8f118141-cd61-46c1-ab8c-15871f118c34" />

Tooltip video

https://github.com/user-attachments/assets/58c5d181-06bf-409f-b44c-5e92665664b4

Issue: https://github.com/coder/coder/issues/18431
Related coder PR: https://github.com/coder/coder/pull/19651

### Changes

- Added `tooltip` to the `app` schema with a max length of 2048 characters
- Updated `app` documentation to include the `tooltip` field
- Added an example `tooltip`

### Testing

- Added tests for empty, valid, and max length (to test validation logic)