### PR TITLE
chore: update workspace resource description

### DIFF
--- a/docs/data-sources/workspace.md
+++ b/docs/data-sources/workspace.md
@@ -67,7 +67,7 @@ resource "docker_container" "workspace" {
 ### Read-Only
 
 - `access_port` (Number) The access port of the Coder deployment provisioning this workspace.
-- `access_url` (String) The access URL of the Coder deployment provisioning this workspace.
+- `access_url` (String) The access URL of the Coder deployment provisioning this workspace. This is the base URL without a trailing slash (e.g., "https://coder.example.com" or "https://coder.example.com:8080").
 - `id` (String) UUID of the workspace.
 - `is_prebuild` (Boolean) Similar to `prebuild_count`, but a boolean value instead of a count. This is set to true if the workspace is a currently unassigned prebuild. Once the workspace is assigned, this value will be false.
 - `is_prebuild_claim` (Boolean) Indicates whether a prebuilt workspace has just been claimed and this is the first `apply` after that occurrence.

--- a/provider/workspace.go
+++ b/provider/workspace.go
@@ -98,7 +98,7 @@ func workspaceDataSource() *schema.Resource {
 			"access_url": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The access URL of the Coder deployment provisioning this workspace.",
+				Description: `The access URL of the Coder deployment provisioning this workspace. This is the base URL without a trailing slash (e.g., "https://coder.example.com" or "https://coder.example.com:8080").`,
 			},
 			"access_port": {
 				Type:        schema.TypeInt,


### PR DESCRIPTION
Fixes: https://github.com/coder/terraform-provider-coder/issues/430

This PR updates the description of `coder_workspace` according to Blink's suggestions (skip trailing slash).