### PR TITLE
feat: add `enabled` computed field to `coder_ai_task`

### DIFF
--- a/docs/resources/ai_task.md
+++ b/docs/resources/ai_task.md
@@ -22,6 +22,7 @@ Use this resource to define Coder tasks.
 
 ### Read-Only
 
+- `enabled` (Boolean) True when executing in a Coder Task context, false when in a Coder Workspace context
 - `id` (String) A unique identifier for this resource.
 - `prompt` (String) The prompt text provided to the task by Coder.
 

--- a/integration/coder-ai-task/main.tf
+++ b/integration/coder-ai-task/main.tf
@@ -41,10 +41,11 @@ resource "coder_ai_task" "task" {
 locals {
   # NOTE: these must all be strings in the output
   output = {
-    "ai_task.id"     = coder_ai_task.task.id
-    "ai_task.app_id" = coder_ai_task.task.app_id
-    "ai_task.prompt" = coder_ai_task.task.prompt
-    "app.id"         = coder_app.ai_interface.id
+    "ai_task.id"      = coder_ai_task.task.id
+    "ai_task.app_id"  = coder_ai_task.task.app_id
+    "ai_task.prompt"  = coder_ai_task.task.prompt
+    "ai_task.enabled" = tostring(coder_ai_task.task.enabled)
+    "app.id"          = coder_app.ai_interface.id
   }
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -215,10 +215,11 @@ func TestIntegration(t *testing.T) {
 			name:       "coder-ai-task",
 			minVersion: "v2.26.0",
 			expectedOutput: map[string]string{
-				"ai_task.id":     `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
-				"ai_task.prompt": "",
-				"ai_task.app_id": `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
-				"app.id":         `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+				"ai_task.id":      `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+				"ai_task.prompt":  "",
+				"ai_task.app_id":  `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+				"ai_task.enabled": "false",
+				"app.id":          `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
 			},
 		},
 	} {


### PR DESCRIPTION
As discussed, we want to enable a way for consumers to know if their template is being provisioned as a task or not. We know that `CODER_TASK_ID` is set by the provisioner, it is being provisioned as a task, and not as a usual workspace. We use this knowledge to set a computed field `enabled` to reflect this.