### PR TITLE
chore(integration): fix failing coder-ai-task integration test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -43,7 +43,7 @@ func TestIntegration(t *testing.T) {
 
 	coderImg := os.Getenv("CODER_IMAGE")
 	if coderImg == "" {
-		coderImg = "ghcr.io/coder/coder"
+		coderImg = "ghcr.io/coder/coder-preview"
 	}
 
 	coderVersion := os.Getenv("CODER_VERSION")
@@ -215,10 +215,10 @@ func TestIntegration(t *testing.T) {
 			name:       "coder-ai-task",
 			minVersion: "v2.26.0",
 			expectedOutput: map[string]string{
-				"ai_task.id":     `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
+				"ai_task.id":     `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
 				"ai_task.prompt": "default",
-				"ai_task.app_id": `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
-				"app.id":         `^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`,
+				"ai_task.app_id": `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
+				"app.id":         `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
 			},
 		},
 	} {


### PR DESCRIPTION
This integration test was failing with:

```
        integration_test.go:258: exec container cmd: "cat /tmp/coder-ai-task.json"
        integration_test.go:258: exec container output:
            {"ai_task.app_id":"d217bbbe-4b3d-4cd3-bf26-08afe1eec0fe","ai_task.id":"00000000-0000-0000-0000-000000000000","ai_task.prompt":"default","app.id":"d217bbbe-4b3d-4cd3-bf26-08afe1eec0fe"}
        integration_test.go:262: 
                Error Trace:    /home/coder/src/coder/terraform-provider-coder/integration/integration_test.go:428
                                                        /home/coder/src/coder/terraform-provider-coder/integration/integration_test.go:262
                Error:          Expect "00000000-0000-0000-0000-000000000000" to match "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
                Test:           TestIntegration/coder-ai-task
                Messages:       output key "ai_task.id" does not have expected value
```

I _think_ this is the correct fix but I'm not sure what was going on with those specific UUIDs.