### PR TITLE
fix: set default value for `coder_ai_task.prompt` to an empty string

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -216,7 +216,7 @@ func TestIntegration(t *testing.T) {
 			minVersion: "v2.26.0",
 			expectedOutput: map[string]string{
 				"ai_task.id":     `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
-				"ai_task.prompt": "default",
+				"ai_task.prompt": "",
 				"ai_task.app_id": `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
 				"app.id":         `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`,
 			},

--- a/provider/ai_task.go
+++ b/provider/ai_task.go
@@ -45,8 +45,6 @@ func aiTaskResource() *schema.Resource {
 
 			if prompt := os.Getenv("CODER_TASK_PROMPT"); prompt != "" {
 				resourceData.Set("prompt", prompt)
-			} else {
-				resourceData.Set("prompt", "default")
 			}
 
 			var (


### PR DESCRIPTION
Instead of defaulting to "default" for the prompt, we should just leave it empty.