### PR TITLE
ci: fail Lint gen on newly created files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,4 +158,9 @@ jobs:
       - name: Lint gen
         run: |
           make gen
-          git diff --exit-code
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "make gen produced changes; run 'make gen' locally and commit the result:"
+            git status --porcelain
+            git --no-pager diff
+            exit 1
+          fi


### PR DESCRIPTION
The "Lint gen" step runs `make gen` and then `git diff --exit-code`. That
check only inspects tracked files, so when `make gen` produces a brand
new Markdown doc (e.g. for a new resource or data source added via
`terraform-plugin-docs`), the generated file stays untracked and CI
passes while the author's local `docs/` is the only place the file
exists.

Reproducing on a clean `main`:

```console
$ echo "## new" > docs/resources/brand-new-resource.md
$ git diff --exit-code; echo $?
0
```

Switch to `git status --porcelain`, which reports modifications and
untracked output, and print the offending paths and diff so the failure
is actionable.

<sub>Generated by Coder Agents on behalf of @zedkipp.</sub>

Originally discovered this problem here: https://github.com/coder/terraform-provider-coder/pull/501#discussion_r3125023968
