### PR TITLE
chore: update Go from 1.26.0 to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/terraform-provider-coder/v2
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/docker/docker v26.1.5+incompatible


### PR DESCRIPTION
Superseded by #527, which updates Go to 1.26.5 instead.

## Summary

Updates the Go version in `go.mod` from 1.26.0 to 1.26.4 to pick up security patches from the [Go 1.26.4 release](https://groups.google.com/g/golang-announce/c/tKs3rmcBcKw).

### CVEs addressed

- **CVE-2026-42504**: Quadratic complexity in `mime.WordDecoder.DecodeHeader` (DoS via crafted MIME headers)
- **CVE-2026-42507**: `net/textproto` log injection via unescaped error inputs
- **CVE-2026-27145**: Quadratic complexity in `crypto/x509.Certificate.VerifyHostname`

Closes https://github.com/coder/terraform-provider-coder/issues/515

> Generated by Coder Agents ([ENG-2854](https://linear.app/codercom/issue/ENG-2854))