### PR TITLE
feat(devcontainer): add optional name attribute to prevent sub-agent name collisions

### DIFF
--- a/provider/devcontainer.go
+++ b/provider/devcontainer.go
@@ -32,6 +32,12 @@ func devcontainerResource() *schema.Resource {
 				ForceNew:    true,
 				Required:    true,
 			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "A custom name for the sub-agent. If not set, the Terraform block name is used. Required when using `for_each` or `count` to avoid name collisions.",
+				ForceNew:    true,
+				Optional:    true,
+			},
 			"workspace_folder": {
 				Type:         schema.TypeString,
 				Description:  "The workspace folder to for the Dev Container.",

--- a/provider/devcontainer_test.go
+++ b/provider/devcontainer_test.go
@@ -105,3 +105,32 @@ func TestDevcontainerNoWorkspaceFolder(t *testing.T) {
 		}},
 	})
 }
+
+func TestDevcontainerWithName(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: coderFactory(),
+		IsUnitTest:        true,
+		Steps: []resource.TestStep{{
+			Config: `
+			provider "coder" {
+			}
+			resource "coder_devcontainer" "example" {
+				agent_id = "king"
+				name = "my-custom-name"
+				workspace_folder = "/workspace"
+				config_path = "/workspace/devcontainer.json"
+			}
+			`,
+			Check: func(state *terraform.State) error {
+				require.Len(t, state.Modules, 1)
+				require.Len(t, state.Modules[0].Resources, 1)
+				script := state.Modules[0].Resources["coder_devcontainer.example"]
+				require.NotNil(t, script)
+				require.Equal(t, "my-custom-name", script.Primary.Attributes["name"])
+				return nil
+			},
+		}},
+	})
+}


### PR DESCRIPTION
## Problem

When using `for_each` or `count` with `coder_devcontainer`, all instances share the same Terraform block name, causing sub-agent name collisions:

```
insert devcontainer "repos" subagent: insert subagent:
pq: workspace agent name "repos" already exists in this workspace build
```

## Fix

Added an optional `name` attribute to the `coder_devcontainer` resource schema. When set, this name takes precedence over the Terraform block name when constructing the sub-agent name.

```hcl
resource "coder_devcontainer" "repos" {
  for_each         = local.repos
  name             = each.value   # new attribute
  agent_id         = coder_agent.dev[0].id
  workspace_folder = "/home/user/workspaces/${each.value}"
  config_path      = "..."
}
```

## Testing

Added `TestDevcontainerWithName` test case verifying the new attribute is properly stored.

Note: Server-side changes in `coder/coder` are also needed to read and use this `name` attribute when constructing the `proto.Devcontainer`.

Fixes #503