### PR TITLE
chore: add check-latest to setup-go for reliable Go version resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+          check-latest: true
         id: go
 
       - name: Get dependencies
@@ -87,6 +88,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+          check-latest: true
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+          check-latest: true
         id: go
 
       - name: Get dependencies
@@ -106,6 +107,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+          check-latest: true
         id: go
 
       - uses: hashicorp/setup-terraform@v4
@@ -139,6 +141,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+          check-latest: true
         id: go
 
       - uses: hashicorp/setup-terraform@v4


### PR DESCRIPTION
## Problem

Our CI workflows use `go-version: "1.26"` with `actions/setup-go@v6`, which is intended to resolve to the latest Go 1.26.x patch. However, `setup-go` defaults to `check-latest: false`, which means it checks the **runner's local tool cache first** before consulting the [go-versions manifest](https://github.com/actions/go-versions). If a matching version exists in the cache (e.g. Go 1.26.4), it uses it immediately — even when a newer patch (e.g. 1.26.5) is available in the manifest.

This caused CI failures whenever `go.mod` required a patch version newer than what was cached on the runner:

```
Found in cache @ /opt/hostedtoolcache/go/1.26.4/x64
...
go: go.mod requires go >= 1.26.5 (running go 1.26.4; GOTOOLCHAIN=local)
```

More broadly, this means any future Go patch bump in the 1.26.x series could break CI until the runner images are updated with the new version — defeating the purpose of using a minor-only version spec.

## Fix

Adds `check-latest: true` to all `actions/setup-go@v6` steps. This tells setup-go to always check the manifest for the latest matching version, even when a match exists in the local cache. With this change, `go-version: "1.26"` reliably resolves to the latest 1.26.x patch.

Confirmed working — CI now resolves to Go 1.26.5 from the manifest:

```
Attempting to resolve the latest version from the manifest...
matching 1.26...
Resolved as '1.26.5'
```