### PR TITLE
fix(provider): validate coder_app URL scheme for external apps

### DIFF
--- a/provider/app.go
+++ b/provider/app.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"regexp"
 
 	"github.com/google/uuid"
@@ -72,6 +74,31 @@ func appResource() *schema.Resource {
 			return nil
 		},
 		DeleteContext: func(ctx context.Context, rd *schema.ResourceData, i any) diag.Diagnostics {
+			return nil
+		},
+		CustomizeDiff: func(ctx context.Context, rd *schema.ResourceDiff, i any) error {
+			if !rd.Get("external").(bool) {
+				return nil
+			}
+
+			rawURL, ok := rd.GetOk("url")
+			if !ok {
+				return nil
+			}
+
+			rawURLStr, ok := rawURL.(string)
+			if !ok {
+				return fmt.Errorf("unexpected type %T for url, expected string", rawURL)
+			}
+
+			parsedURL, err := url.Parse(rawURLStr)
+			if err != nil {
+				return fmt.Errorf("invalid \"coder_app\" url %q for external app: %w", rawURLStr, err)
+			}
+			if parsedURL.Scheme == "" || parsedURL.Host == "" {
+				return fmt.Errorf("invalid \"coder_app\" url %q for external app: must include a scheme and host", rawURLStr)
+			}
+
 			return nil
 		},
 		Schema: map[string]*schema.Schema{

--- a/provider/app.go
+++ b/provider/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-cty/cty"
@@ -81,22 +82,20 @@ func appResource() *schema.Resource {
 				return nil
 			}
 
-			rawURL, ok := rd.GetOk("url")
+			rawURL, ok := rd.Get("url").(string)
 			if !ok {
-				return nil
+				return fmt.Errorf("unexpected type %T for url, expected string", rd.Get("url"))
+			}
+			if strings.TrimSpace(rawURL) == "" {
+				return fmt.Errorf("invalid \"coder_app\" url %q for external app: must include a scheme and host", rawURL)
 			}
 
-			rawURLStr, ok := rawURL.(string)
-			if !ok {
-				return fmt.Errorf("unexpected type %T for url, expected string", rawURL)
-			}
-
-			parsedURL, err := url.Parse(rawURLStr)
+			parsedURL, err := url.Parse(rawURL)
 			if err != nil {
-				return fmt.Errorf("invalid \"coder_app\" url %q for external app: %w", rawURLStr, err)
+				return fmt.Errorf("invalid \"coder_app\" url %q for external app: %w", rawURL, err)
 			}
-			if parsedURL.Scheme == "" || parsedURL.Host == "" {
-				return fmt.Errorf("invalid \"coder_app\" url %q for external app: must include a scheme and host", rawURLStr)
+			if parsedURL.Scheme == "" || parsedURL.Hostname() == "" {
+				return fmt.Errorf("invalid \"coder_app\" url %q for external app: must include a scheme and host", rawURL)
 			}
 
 			return nil

--- a/provider/app_test.go
+++ b/provider/app_test.go
@@ -110,6 +110,24 @@ func TestApp(t *testing.T) {
 			`,
 			external: true,
 		}, {
+			name: "EmptyURL",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = ""
+				external = true
+				open_in = "slim-window"
+			}
+			`,
+			expectError: regexp.MustCompile(`must include a scheme and host`),
+		}, {
 			name: "MissingScheme",
 			config: `
 			provider "coder" {}
@@ -140,6 +158,24 @@ func TestApp(t *testing.T) {
 				slug = "test"
 				display_name = "Testing"
 				url = "https://"
+				external = true
+				open_in = "slim-window"
+			}
+			`,
+			expectError: regexp.MustCompile(`must include a scheme and host`),
+		}, {
+			name: "NoHostname",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "https://:8080"
 				external = true
 				open_in = "slim-window"
 			}

--- a/provider/app_test.go
+++ b/provider/app_test.go
@@ -109,6 +109,42 @@ func TestApp(t *testing.T) {
 			}
 			`,
 			external: true,
+		}, {
+			name: "MissingScheme",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "google.com"
+				external = true
+				open_in = "slim-window"
+			}
+			`,
+			expectError: regexp.MustCompile(`must include a scheme and host`),
+		}, {
+			name: "MissingHost",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "https://"
+				external = true
+				open_in = "slim-window"
+			}
+			`,
+			expectError: regexp.MustCompile(`must include a scheme and host`),
 		}}
 		for _, tc := range cases {
 			tc := tc


### PR DESCRIPTION
## Summary

Validate `coder_app.url` when `external = true` so external apps require both a URL scheme and a host.

## Changes

- reject external app URLs missing a scheme or host
- add regression tests for missing-scheme and missing-host inputs

## Validation

- `go test ./provider/...`
