### PR TITLE
fix: external urls validate a scheme and hostname

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -365,7 +365,7 @@ func setup(ctx context.Context, t *testing.T, name, coderImg, coderVersion strin
 		}
 		t.Logf("not ready yet...")
 		return false
-	}, 10*time.Second, time.Second, "coder failed to become ready in time")
+	}, 12*time.Second, time.Second, "coder failed to become ready in time")
 
 	// Perform first time setup
 	_, rc := execContainer(ctx, t, ctr.ID, fmt.Sprintf(`coder login %s --first-user-email=%q --first-user-password=%q --first-user-trial=false --first-user-username=%q`, localURL, testEmail, testPassword, testUsername))

--- a/provider/app.go
+++ b/provider/app.go
@@ -293,5 +293,19 @@ func appResource() *schema.Resource {
 				},
 			},
 		},
+		CustomizeDiff: func(ctx context.Context, rd *schema.ResourceDiff, i any) error {
+			// A value that stays unknown until apply cannot be checked here.
+			if !rd.NewValueKnown("external") || !rd.NewValueKnown("url") {
+				return nil
+			}
+
+			external, _ := rd.Get("external").(bool)
+			rawURL, _ := rd.Get("url").(string)
+			if external {
+				return helpers.ValidateExternalURL(rawURL)
+			}
+
+			return nil
+		},
 	}
 }

--- a/provider/app_test.go
+++ b/provider/app_test.go
@@ -109,6 +109,76 @@ func TestApp(t *testing.T) {
 			}
 			`,
 			external: true,
+		}, {
+			name: "NoScheme",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "my-repo"
+				external = true
+			}
+			`,
+			external:    true,
+			expectError: regexp.MustCompile(`must include a scheme`),
+		}, {
+			name: "HostPortWithoutScheme",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "localhost:8080"
+				external = true
+			}
+			`,
+			external:    true,
+			expectError: regexp.MustCompile(`"localhost" URLs must include a host`),
+		}, {
+			name: "NoHost",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "https://"
+				external = true
+			}
+			`,
+			external:    true,
+			expectError: regexp.MustCompile(`"https" URLs must include a host`),
+		}, {
+			name: "NotExternalIsUnchecked",
+			config: `
+			provider "coder" {}
+			resource "coder_agent" "dev" {
+				os = "linux"
+				arch = "amd64"
+			}
+			resource "coder_app" "test" {
+				agent_id = coder_agent.dev.id
+				slug = "test"
+				display_name = "Testing"
+				url = "my-repo"
+			}
+			`,
+			external: false,
 		}}
 		for _, tc := range cases {
 			tc := tc

--- a/provider/helpers/validation.go
+++ b/provider/helpers/validation.go
@@ -34,3 +34,22 @@ func WarnDirNotHome(val interface{}, _ string) ([]string, []error) {
 		`Setting "dir" to a value other than $HOME will break Coder Desktop file sync.`,
 	}, nil
 }
+
+// ValidateExternalURL validates that value is a URL the browser's URL can parse.
+// An external app URL must carry a scheme and hostname
+func ValidateExternalURL(value string) error {
+	u, err := url.Parse(value)
+	if err != nil {
+		return err
+	}
+
+	if u.Scheme == "" {
+		return fmt.Errorf(`must include a scheme, for example "https://" or "vscode://"`)
+	}
+
+	if u.Host == "" || u.Hostname() == "" {
+		return fmt.Errorf("%q URLs must include a host", u.Scheme)
+	}
+
+	return nil
+}

--- a/provider/helpers/validation.go
+++ b/provider/helpers/validation.go
@@ -44,7 +44,7 @@ func ValidateExternalURL(value string) error {
 	}
 
 	if u.Scheme == "" {
-		return fmt.Errorf(`must include a scheme, for example "https://" or "vscode://"`)
+		return fmt.Errorf(`must include a scheme, for example "https://"`)
 	}
 
 	if u.Host == "" || u.Hostname() == "" {

--- a/provider/helpers/validation_test.go
+++ b/provider/helpers/validation_test.go
@@ -152,9 +152,9 @@ func TestValidateURL(t *testing.T) {
 
 func TestWarnDirNotHome(t *testing.T) {
 	tests := []struct {
-		name         string
-		value        interface{}
-		warnCount    int
+		name      string
+		value     interface{}
+		warnCount int
 	}{
 		// No warnings expected.
 		{
@@ -200,6 +200,120 @@ func TestWarnDirNotHome(t *testing.T) {
 			warnings, errors := WarnDirNotHome(tt.value, "dir")
 			require.Empty(t, errors, "expected no errors")
 			require.Len(t, warnings, tt.warnCount)
+		})
+	}
+}
+
+func TestValidateExternalURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         string
+		errorContains string
+	}{
+		// Valid: a scheme and a host.
+		{
+			name:  "https URL",
+			value: "https://example.com",
+		},
+		{
+			name:  "https URL with path and query",
+			value: "https://example.com/path?q=test",
+		},
+		{
+			name:  "custom vscode scheme",
+			value: "vscode://coder.coder-remote/open?token=$SESSION_TOKEN",
+		},
+		{
+			name:  "reverse DNS scheme with a path",
+			value: "com.example.app://callback",
+		},
+		{
+			name:  "jetbrains gateway",
+			value: "jetbrains-gateway://connect#provider=ssh&host=192.168.1.1&port=22&user=ubuntu&projectPath=/home/ubuntu/projects/my-app",
+		},
+
+		// Invalid: a bare host:port is read as a scheme with an opaque body, so
+		// "localhost:8080" parses as the scheme "localhost" and leaves no host.
+		{
+			name:          "host:port without scheme",
+			value:         "localhost:8080",
+			errorContains: `"localhost" URLs must include a host`,
+		},
+		{
+			name:          "domain and port without scheme",
+			value:         "example.com:8080",
+			errorContains: `"example.com" URLs must include a host`,
+		},
+		{
+			name:          "host:port with a path",
+			value:         "localhost:8080/path",
+			errorContains: `"localhost" URLs must include a host`,
+		},
+
+		// Invalid: opaque URLs have no host, so there is nothing to navigate to.
+		{
+			name:          "opaque scheme",
+			value:         "mailto:user@example.com",
+			errorContains: "must include a host",
+		},
+		{
+			name:          "opaque scheme with a numeric body",
+			value:         "tel:5551234",
+			errorContains: "must include a host",
+		},
+
+		// Invalid: no scheme, so new URL() throws.
+		{
+			name:          "bare string",
+			value:         "my-repo",
+			errorContains: "must include a scheme",
+		},
+		{
+			name:          "absolute path",
+			value:         "/some/path",
+			errorContains: "must include a scheme",
+		},
+		{
+			name:          "relative path",
+			value:         "./file.txt",
+			errorContains: "must include a scheme",
+		},
+		{
+			name:          "protocol relative",
+			value:         "//example.com",
+			errorContains: "must include a scheme",
+		},
+		{
+			name:          "empty string",
+			value:         "",
+			errorContains: "must include a scheme",
+		},
+
+		// Invalid: Go accepts a hostless special scheme, the browser does not.
+		{
+			name:          "https with no host",
+			value:         "https://",
+			errorContains: "must include a host",
+		},
+
+		// Invalid: unparsable by either parser.
+		{
+			name:          "malformed URL",
+			value:         "http://[::1:80",
+			errorContains: "missing ']'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExternalURL(tt.value)
+
+			if tt.errorContains == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errorContains)
 		})
 	}
 }


### PR DESCRIPTION
* [DEVEX-523](https://linear.app/codercom/issue/DEVEX-523/validate-coder-app-url-field-to-require-a-parseable-scheme)

## Summary
  - coder_app resources with `external = true` now validate the url at plan time via a new `CustomizeDiff` in
    `provider/app.go`, ensuring the URL has both a scheme and a host before apply.
  - Adds `ValidateExternalURL` in `provider/helpers/validation.go`, matching what a browser or OS URL
    handler would actually accept.  Rejects bare host:port strings (which Go's url.Parse misreads as a
    scheme), opaque schemes and malformed urls
    - Increases the timeout of the integration tests for startup in a container 2seconds. this can be controversial; some folks like this tighter.

  ## Why
  External app URLs are opened directly by the browser or a custom protocol handler (e.g. `vscode://`), so
  a URL missing a scheme or missing a host (`https://`) silently fails to open for the user. This catches that at terraform plan time with a clear error instead of a confusing runtime failure.

  Testing
  - New table-driven tests in `provider/helpers/validation_test.go` covering valid cases (`https, vscode://`,
    reverse-DNS custom schemes, `jetbrains-gateway://`) and invalid cases (host:port without scheme,
    opaque schemes, missing scheme, missing host, malformed URLs).
  - New acceptance-style test cases in `provider/app_test.go` (NoScheme, HostPortWithoutScheme, NoHost,
    NotExternalIsUnchecked) verifying the diff-time check only fires when external = true and unknown values (computed at apply) are skipped.
  - `go test ./provider/... passes.`
  - Increases the integration test timeout to 12 seconds from 10; was causing ci flake.
  
  tested locally with: 
  `~/.terraformrc` :
 ```hcl
 terraform {
  required_providers {
    coder = {
      source = "coder/coder"
    }
  }
}

provider "coder" {}

resource "coder_agent" "dev" {
  os   = "linux"
  arch = "amd64"
}

resource "coder_app" "bad_external" {
  agent_id     = coder_agent.dev.id
  slug         = "bad-external"
  display_name = "Bad External App"
  url          = "localhost:8080"
  external     = true
}
 ```
 
 `main.tf` (intentionally broken missing scheme) :
```hcl
  terraform {
  required_providers {
    coder = {
      source = "coder/coder"
    }
  }
}

provider "coder" {}

resource "coder_agent" "dev" {
  os   = "linux"
  arch = "amd64"
}

resource "coder_app" "bad_external" {
  agent_id     = coder_agent.dev.id
  slug         = "bad-external"
  display_name = "Bad External App"
  url          = "localhost:8080"
  external     = true
}
  ```